### PR TITLE
feat: cache dashboard stats in localStorage to prevent flash of zeros

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ import {
 } from "./utils/dashboard";
 import { clampPage } from "./utils/pagination";
 import { formatNumber } from "./utils/format";
+import { clearStatsCache, readStatsCache, writeStatsCache } from "./utils/statsCache";
 
 type Tab = "repos" | "issues" | "prs" | "kanban" | "insights" | "digests";
 type Theme = "dark" | "light" | "auto";
@@ -188,6 +189,18 @@ export function App() {
     const cachedPrs = peek<PullRequestsData>(CACHE_KEY.prs);
     if (cachedPrs) setPullRequests(cachedPrs.pullRequests);
 
+    // Fall back to localStorage when in-memory cache is empty (page refresh)
+    if (!cachedRepos && !cachedIssues && !cachedPrs) {
+      const persisted = readStatsCache();
+      if (persisted) {
+        setRepos(persisted.repos as GhRepo[]);
+        setOwners(persisted.owners);
+        setIssues(persisted.issues as GhIssue[]);
+        setPullRequests(persisted.pullRequests as GhPullRequest[]);
+        if (persisted.fetchedAt) setFetchedAt(persisted.fetchedAt);
+      }
+    }
+
     let pending = 3;
     setLoading(true);
     const finish = () => {
@@ -257,6 +270,18 @@ export function App() {
 
   useEffect(() => () => abortRef.current?.abort(), []);
 
+  // Persist dashboard data to localStorage for instant display on next page load
+  useEffect(() => {
+    if (repos.length === 0 && issues.length === 0 && pullRequests.length === 0) return;
+    writeStatsCache({
+      repos,
+      owners,
+      issues,
+      pullRequests,
+      fetchedAt,
+    });
+  }, [repos, owners, issues, pullRequests, fetchedAt]);
+
   useEffect(() => {
     if (authState !== "authenticated") return;
     if (tab !== "insights" && tab !== "repos") return;
@@ -299,6 +324,7 @@ export function App() {
       // ignore — UI flips regardless
     }
     invalidateCache();
+    clearStatsCache();
     setAuthState("anonymous");
     setAuthLogin(null);
     setIssues([]);

--- a/src/utils/statsCache.ts
+++ b/src/utils/statsCache.ts
@@ -1,0 +1,59 @@
+/**
+ * Persists dashboard API responses to localStorage so that subsequent page
+ * loads can display last-known values immediately (avoiding a flash of zeros).
+ */
+
+const STORAGE_PREFIX = "gh-dash.cache.";
+
+export interface CachedStats {
+  repos: unknown[];
+  owners: string[];
+  issues: unknown[];
+  pullRequests: unknown[];
+  fetchedAt: string;
+  savedAt: number;
+}
+
+const STATS_KEY = `${STORAGE_PREFIX}stats`;
+
+/**
+ * Read cached stats from localStorage.
+ * Returns null if no cache exists or if the data is unparseable.
+ */
+export function readStatsCache(): CachedStats | null {
+  try {
+    const raw = localStorage.getItem(STATS_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CachedStats;
+    // Basic shape validation
+    if (!Array.isArray(parsed.repos) || !Array.isArray(parsed.issues) || !Array.isArray(parsed.pullRequests)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write stats to localStorage. Silently fails on quota errors.
+ */
+export function writeStatsCache(data: Omit<CachedStats, "savedAt">): void {
+  try {
+    const entry: CachedStats = { ...data, savedAt: Date.now() };
+    localStorage.setItem(STATS_KEY, JSON.stringify(entry));
+  } catch {
+    // Quota exceeded or private browsing — ignore silently
+  }
+}
+
+/**
+ * Remove cached stats (e.g. on logout or account switch).
+ */
+export function clearStatsCache(): void {
+  try {
+    localStorage.removeItem(STATS_KEY);
+  } catch {
+    // Ignore
+  }
+}

--- a/tests/utils/statsCache.test.ts
+++ b/tests/utils/statsCache.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearStatsCache, readStatsCache, writeStatsCache } from "../../src/utils/statsCache";
+
+describe("statsCache", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when no cache exists", () => {
+    expect(readStatsCache()).toBeNull();
+  });
+
+  it("writes and reads back cached stats", () => {
+    const data = {
+      repos: [{ nameWithOwner: "acme/app", stargazerCount: 10 }],
+      owners: ["acme"],
+      issues: [{ title: "Bug" }],
+      pullRequests: [{ title: "Fix" }],
+      fetchedAt: "2026-04-29T10:00:00Z",
+    };
+
+    writeStatsCache(data);
+    const result = readStatsCache();
+
+    expect(result).not.toBeNull();
+    expect(result!.repos).toEqual(data.repos);
+    expect(result!.owners).toEqual(data.owners);
+    expect(result!.issues).toEqual(data.issues);
+    expect(result!.pullRequests).toEqual(data.pullRequests);
+    expect(result!.fetchedAt).toBe(data.fetchedAt);
+    expect(result!.savedAt).toBeGreaterThan(0);
+  });
+
+  it("clears cached stats", () => {
+    writeStatsCache({
+      repos: [],
+      owners: [],
+      issues: [],
+      pullRequests: [],
+      fetchedAt: "",
+    });
+
+    clearStatsCache();
+    expect(readStatsCache()).toBeNull();
+  });
+
+  it("returns null for corrupted JSON", () => {
+    localStorage.setItem("gh-dash.cache.stats", "not-json{{{");
+    expect(readStatsCache()).toBeNull();
+  });
+
+  it("returns null if data shape is invalid", () => {
+    localStorage.setItem("gh-dash.cache.stats", JSON.stringify({ repos: "not-array" }));
+    expect(readStatsCache()).toBeNull();
+  });
+
+  it("handles localStorage quota errors gracefully", () => {
+    const originalSetItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new DOMException("QuotaExceededError");
+    };
+
+    // Should not throw
+    expect(() => writeStatsCache({
+      repos: [],
+      owners: [],
+      issues: [],
+      pullRequests: [],
+      fetchedAt: "",
+    })).not.toThrow();
+
+    Storage.prototype.setItem = originalSetItem;
+  });
+});


### PR DESCRIPTION
## Problem

On every page refresh, all dashboard stats (repositories count, stars, forks, issues, PRs) flash as **0** until the GitHub API responds. This creates a jarring UX, especially on slower connections.

## Solution

Persist the last-known API response data to `localStorage` so subsequent page loads can display cached values immediately.

### How it works

1. **On page load**: if the in-memory SWR cache is empty (always the case after refresh), read from `localStorage` and seed React state.
2. **After API response**: a `useEffect` watches the data arrays and persists them to `localStorage`.
3. **On logout**: clears the `localStorage` cache to prevent stale cross-account data.

### Error resilience

All `localStorage` operations are wrapped in try/catch. If `localStorage` is disabled, full, or corrupted, the app behaves exactly as it does today — no regressions. The cache is strictly an enhancement.

### Files changed

| File | Change |
|------|--------|
| `src/utils/statsCache.ts` | **New** — Pure read/write/clear functions for localStorage |
| `tests/utils/statsCache.test.ts` | **New** — 6 unit tests (happy path, corruption, quota errors) |
| `src/App.tsx` | **Modified** — 4 small edits: import, localStorage fallback in `loadData`, persistence `useEffect`, clear on logout |

### Test plan

- [x] `npm test` — all 40 tests pass (34 existing + 6 new)
- [x] `npm run build` — builds cleanly
- [ ] Manual: load page → observe data → refresh → confirm no zero flash
- [ ] Manual: logout → login with different account → confirm fresh data
- [ ] Manual: disable localStorage in DevTools → confirm graceful degradation