### PR TITLE
feat: localStorage persistence, responsive fixes, and UX improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ import {
 import { clampPage } from "./utils/pagination";
 import { formatNumber } from "./utils/format";
 import { clearStatsCache, readStatsCache, writeStatsCache } from "./utils/statsCache";
+import { clearFiltersCache, hydrateFilters, readFiltersCache, writeFiltersCache } from "./utils/filtersCache";
 
 type Tab = "inbox" | "repos" | "issues" | "prs" | "kanban" | "insights" | "digests";
 type Theme = "dark" | "light" | "auto";
@@ -152,6 +153,12 @@ export function App() {
   const repoDetailTab = detailTabFromParams(searchParams);
   const routeMetricKind = metricKindFromParams(searchParams);
 
+  // Read cached filters once — shared across all filter/sort useState initializers below.
+  const [cachedFiltersOnMount] = useState(() => {
+    const raw = readFiltersCache();
+    return raw ? { hydrated: hydrateFilters(raw), sorts: raw.sorts } : null;
+  });
+
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [authLogin, setAuthLogin] = useState<string | null>(null);
   const [issues, setIssues] = useState<GhIssue[]>([]);
@@ -166,12 +173,14 @@ export function App() {
   const [error, setError] = useState("");
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem("gh-dash.theme") as Theme) || "dark");
-  const [issueFilters, setIssueFilters] = useState<IssueFilters>(() => defaultIssueFilters());
-  const [prFilters, setPrFilters] = useState<PullRequestFilters>(() => defaultPrFilters());
-  const [repoFilters, setRepoFilters] = useState<RepoFilters>(() => defaultRepoFilters());
-  const [issueSort, setIssueSort] = useState("updated_desc");
-  const [prSort, setPrSort] = useState("updated_desc");
-  const [repoSort, setRepoSort] = useState("stars_desc");
+  const [issueFilters, setIssueFilters] = useState<IssueFilters>(() => cachedFiltersOnMount?.hydrated.issueFilters ?? defaultIssueFilters());
+  const [prFilters, setPrFilters] = useState<PullRequestFilters>(() => cachedFiltersOnMount?.hydrated.prFilters ?? defaultPrFilters());
+  const [repoFilters, setRepoFilters] = useState<RepoFilters>(() => cachedFiltersOnMount?.hydrated.repoFilters ?? defaultRepoFilters());
+  const [issueSort, setIssueSort] = useState(() => cachedFiltersOnMount?.sorts?.issueSort || "updated_desc");
+  const [prSort, setPrSort] = useState(() => cachedFiltersOnMount?.sorts?.prSort || "updated_desc");
+  const [repoSort, setRepoSort] = useState(() => cachedFiltersOnMount?.sorts?.repoSort || "stars_desc");
+  // Page numbers are intentionally NOT cached — they're ephemeral positions,
+  // not preferences. After a refresh, page 1 is always the correct start.
   const [issuePage, setIssuePage] = useState(1);
   const [prPage, setPrPage] = useState(1);
   const [repoPage, setRepoPage] = useState(1);
@@ -207,7 +216,6 @@ export function App() {
         setIssues(persisted.issues as GhIssue[]);
         setPullRequests(persisted.pullRequests as GhPullRequest[]);
         if (persisted.fetchedAt) setFetchedAt(persisted.fetchedAt);
-        setDataStale(true);
       }
     }
 
@@ -338,6 +346,7 @@ export function App() {
     }
     invalidateCache();
     clearStatsCache();
+    clearFiltersCache();
     setAuthState("anonymous");
     setAuthLogin(null);
     setIssues([]);
@@ -377,6 +386,11 @@ export function App() {
   useEffect(() => localStorage.setItem("gh-dash.issuesPageSize", String(issuePageSize)), [issuePageSize]);
   useEffect(() => localStorage.setItem("gh-dash.prsPageSize", String(prPageSize)), [prPageSize]);
   useEffect(() => localStorage.setItem("gh-dash.reposPageSize", String(repoPageSize)), [repoPageSize]);
+
+  // Persist sidebar filters and sort order to localStorage
+  useEffect(() => {
+    writeFiltersCache(repoFilters, issueFilters, prFilters, { issueSort, prSort, repoSort });
+  }, [repoFilters, issueFilters, prFilters, issueSort, prSort, repoSort]);
 
   const userLogin = owners[0] || "";
   const issueFacets = useMemo(() => buildIssueFacets(issues), [issues]);
@@ -454,6 +468,7 @@ export function App() {
     if (tab === "repos" || tab === "insights" || tab === "digests") setRepoFilters(defaultRepoFilters());
     else if (tab === "prs") setPrFilters(defaultPrFilters());
     else setIssueFilters(defaultIssueFilters());
+    clearFiltersCache();
   }
 
   function navigateTab(nextTab: Tab) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,7 @@ import {
 } from "./utils/dashboard";
 import { clampPage } from "./utils/pagination";
 import { formatNumber } from "./utils/format";
+import { clearStatsCache, readStatsCache, writeStatsCache } from "./utils/statsCache";
 
 type Tab = "inbox" | "repos" | "issues" | "prs" | "kanban" | "insights" | "digests";
 type Theme = "dark" | "light" | "auto";
@@ -161,6 +162,7 @@ export function App() {
   const [dailyDigests, setDailyDigests] = useState<DailyDigestEntry[]>([]);
   const [fetchedAt, setFetchedAt] = useState("");
   const [loading, setLoading] = useState(false);
+  const [dataStale, setDataStale] = useState(false);
   const [error, setError] = useState("");
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem("gh-dash.theme") as Theme) || "dark");
@@ -195,11 +197,27 @@ export function App() {
     const cachedPrs = peek<PullRequestsData>(CACHE_KEY.prs);
     if (cachedPrs) setPullRequests(cachedPrs.pullRequests);
 
+    // Fall back to localStorage when in-memory cache is empty (page refresh)
+    if (!cachedRepos && !cachedIssues && !cachedPrs) {
+      const persisted = readStatsCache();
+      if (persisted) {
+        setRepos(persisted.repos as GhRepo[]);
+        setOwners(persisted.owners);
+        setIssues(persisted.issues as GhIssue[]);
+        setPullRequests(persisted.pullRequests as GhPullRequest[]);
+        if (persisted.fetchedAt) setFetchedAt(persisted.fetchedAt);
+        setDataStale(true);
+      }
+    }
+
     let pending = 3;
     setLoading(true);
     const finish = () => {
       pending -= 1;
-      if (pending <= 0 && abortRef.current === controller) setLoading(false);
+      if (pending <= 0 && abortRef.current === controller) {
+        setLoading(false);
+        setDataStale(false);
+      }
     };
     const handleFailure = (err: unknown) => {
       if (controller.signal.aborted) return;
@@ -264,6 +282,18 @@ export function App() {
 
   useEffect(() => () => abortRef.current?.abort(), []);
 
+  // Persist dashboard data to localStorage for instant display on next page load
+  useEffect(() => {
+    if (repos.length === 0 && issues.length === 0 && pullRequests.length === 0) return;
+    writeStatsCache({
+      repos,
+      owners,
+      issues,
+      pullRequests,
+      fetchedAt,
+    });
+  }, [repos, owners, issues, pullRequests, fetchedAt]);
+
   useEffect(() => {
     if (authState !== "authenticated") return;
     if (tab !== "insights" && tab !== "repos") return;
@@ -306,6 +336,7 @@ export function App() {
       // ignore — UI flips regardless
     }
     invalidateCache();
+    clearStatsCache();
     setAuthState("anonymous");
     setAuthLogin(null);
     setIssues([]);
@@ -491,7 +522,7 @@ export function App() {
           onReset={resetFilters}
           onClose={() => setFiltersOpen(false)}
         />
-        <main className="main">
+        <main className={`main${dataStale ? " data-stale" : ""}`}>
           {error ? <div className="error">{error}</div> : null}
           <div className="view-head">
             <div className="tabs" role="tablist">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -185,6 +185,7 @@ export function App() {
     const controller = new AbortController();
     abortRef.current = controller;
     setError("");
+    setDataStale(true);
 
     const cachedRepos = peek<ReposData>(CACHE_KEY.repos);
     if (cachedRepos) {

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -53,6 +53,7 @@ export function TopBar({
         <button className="btn auth-btn" aria-label="Sign out" title={authLogin ? `Signed in as ${authLogin}` : "Sign out"} onClick={onLogout}>
           <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline points="16 17 21 12 16 7" /><line x1="21" y1="12" x2="9" y2="12" /></svg>
           <span className="label">{authLogin || "Sign out"}</span>
+          {authLogin && <img className="auth-avatar" src={`https://github.com/${authLogin}.png?size=28`} alt="" width={20} height={20} />}
         </button>
       </div>
     </div>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -7,7 +7,7 @@
     background: var(--bg);
     -webkit-tap-highlight-color: transparent;
   }
-  body { background: var(--bg-grad); min-height: 100vh; }
+  body { background: var(--bg-grad); min-height: 100vh; overflow-x: hidden; }
   button, input, select { font: inherit; color: inherit; }
   a { color: inherit; text-decoration: none; }
   a:hover { text-decoration: underline; }

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -84,6 +84,7 @@
   @keyframes spin { to { transform: rotate(360deg); } }
   .btn .label { display: inline; }
   .auth-btn .label { max-width: 120px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .auth-avatar { width: 20px; height: 20px; border-radius: 50%; flex-shrink: 0; }
   @media (max-width: 900px) {
     .topbar { gap: 10px; }
     .btn { width: 34px; padding: 0; justify-content: center; }

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -129,7 +129,7 @@
 
   /* Tabs */
   .tabs {
-    display: inline-flex; background: color-mix(in srgb, var(--panel) 90%, transparent); border: 1px solid var(--border-soft); border-radius: 8px; padding: 3px; gap: 2px;
+    display: flex; background: color-mix(in srgb, var(--panel) 90%, transparent); border: 1px solid var(--border-soft); border-radius: 8px; padding: 3px; gap: 2px;
     box-shadow: inset 0 1px 0 rgba(255,255,255,0.035);
     max-width: 100%;
     overflow-x: auto;

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -131,8 +131,19 @@
   .tabs {
     display: flex; background: color-mix(in srgb, var(--panel) 90%, transparent); border: 1px solid var(--border-soft); border-radius: 8px; padding: 3px; gap: 2px;
     box-shadow: inset 0 1px 0 rgba(255,255,255,0.035);
-    max-width: 100%;
+    min-width: 0; max-width: 100%;
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x proximity;
+    scrollbar-width: thin;
+  }
+  @media (max-width: 768px) {
+    .tabs {
+      -webkit-mask-image: linear-gradient(to right, black calc(100% - 28px), transparent);
+      mask-image: linear-gradient(to right, black calc(100% - 28px), transparent);
+      padding-right: 24px;
+    }
+    .tab { padding: 7px 10px; font-size: 12px; scroll-snap-align: start; }
   }
   .tab {
     display: inline-flex; align-items: center; gap: 8px;
@@ -153,3 +164,45 @@
     font-variant-numeric: tabular-nums;
   }
   .tab:not(.active) .tab-badge { background: var(--panel-2); color: var(--muted); border: 1px solid var(--border-soft); }
+
+  /* Mobile: icon-only tabs — stretch full width, reveal label on hover */
+  @media (max-width: 640px) {
+    .tabs {
+      -webkit-mask-image: none;
+      mask-image: none;
+      padding-right: 3px;
+      overflow-x: visible;
+      flex-wrap: nowrap;
+      width: 100%;
+    }
+    .tab {
+      font-size: 0;
+      gap: 0;
+      padding: 7px 0;
+      flex: 1 1 0;
+      justify-content: center;
+      overflow: hidden;
+      transition: flex .3s cubic-bezier(0.22, 0.61, 0.36, 1),
+                  gap .3s cubic-bezier(0.22, 0.61, 0.36, 1),
+                  font-size .25s ease .05s,
+                  color .15s ease, background .15s ease;
+    }
+    .tab svg {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+    .tab .tab-badge {
+      font-size: 10px;
+      padding: 0 5px;
+      margin-left: 2px;
+    }
+    /* Reveal label smoothly — tab expands, text slides in from left */
+    .tab:hover,
+    .tab:focus-visible,
+    .tab:active {
+      flex: 4 1 0;
+      font-size: 11px;
+      gap: 5px;
+    }
+  }

--- a/src/styles/views.css
+++ b/src/styles/views.css
@@ -2,6 +2,8 @@
   .main {
     min-width: 0;
     display: grid;
+    /* Explicit column prevents implicit track sizing to content width,
+       which caused horizontal overflow at intermediate viewport widths. */
     grid-template-columns: minmax(0, 1fr);
     align-content: start;
   }

--- a/src/styles/views.css
+++ b/src/styles/views.css
@@ -95,6 +95,49 @@
   .chip .k { color: var(--muted); font-size: 11px; }
   .chip .val { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px; }
 
+  /* Issue list */
+  .list { background: var(--panel); border: 1px solid var(--border-soft); border-radius: 9px; overflow: hidden; box-shadow: 0 1px 0 rgba(255,255,255,0.035); }
+  .issue {
+    display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 14px;
+    padding: 14px 16px; border-bottom: 1px solid var(--border-soft);
+    transition: background .1s ease;
+  }
+  @media (min-width: 720px) { .issue { padding: 14px 18px; } }
+  @media (max-width: 600px) {
+    .issue { grid-template-columns: 1fr; gap: 10px; }
+    .issue .aside-col { flex-direction: row !important; gap: 10px !important; align-items: center !important; flex-wrap: wrap; }
+  }
+  .issue:last-child { border-bottom: none; }
+  .issue:hover { background: var(--hover-surface); }
+  .issue .main-col { min-width: 0; }
+  .issue .aside-col { display: flex; flex-direction: column; align-items: flex-end; gap: 6px; white-space: nowrap; color: var(--muted); font-size: 12px; }
+
+  .issue .row1 { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--muted); margin-bottom: 4px; flex-wrap: wrap; }
+  .repo-pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px;
+    padding: 2px 8px; color: var(--text); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11.5px;
+    max-width: 100%; overflow: hidden; text-overflow: ellipsis;
+  }
+  .repo-pill .sep { color: var(--muted-2); }
+  .issue .num { color: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+  .title-link { font-size: 14.5px; font-weight: 600; color: var(--text); line-height: 1.35; display: inline-block; word-break: break-word; }
+  .title-link:hover { color: var(--accent-2); text-decoration: none; }
+
+  .labels { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px; }
+  .label {
+    display: inline-flex; align-items: center; gap: 5px;
+    font-size: 11px; padding: 2px 8px; border-radius: 999px;
+    border: 1px solid rgba(255,255,255,0.08);
+  }
+  .btn.theme-btn > .label,
+  .btn.primary > .label { border-color: transparent; }
+  .label .dot { width: 7px; height: 7px; border-radius: 50%; }
+
+  .meta-row { display: flex; align-items: center; gap: 10px; margin-top: 8px; color: var(--muted); font-size: 12px; flex-wrap: wrap; }
+  .meta-row .sep { color: var(--muted-2); }
+  .author-chip { display: inline-flex; align-items: center; gap: 6px; color: var(--text); }
+
   /* Shared avatar (used in lists, inbox, modals) */
   .avatar {
     display: inline-flex;

--- a/src/styles/views.css
+++ b/src/styles/views.css
@@ -2,6 +2,7 @@
   .main {
     min-width: 0;
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     align-content: start;
   }
 
@@ -14,7 +15,7 @@
   }
 
   .stats {
-    display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(min(190px, 100%), 1fr));
     gap: 10px; margin-bottom: 14px;
   }
   @media (max-width: 720px) { .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; } }
@@ -375,6 +376,7 @@
     padding: 14px 16px; display: flex; flex-direction: column; gap: 10px;
     transition: border-color .12s ease; min-width: 0; cursor: pointer;
     box-shadow: 0 1px 0 rgba(255,255,255,0.035);
+    overflow: hidden;
   }
   .repo-card:hover { border-color: var(--button-hover-border); }
   .repo-card:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/src/styles/views.css
+++ b/src/styles/views.css
@@ -590,3 +590,19 @@
   }
   .rc-stat.clickable:hover { background: var(--hover-surface-strong); color: var(--text); }
   .rc-stat.clickable:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+  /* Stale data indicator — cached values pulse softly until fresh API data arrives */
+  @keyframes stale-pulse {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 0.7; }
+  }
+  .main.data-stale .stat .v,
+  .main.data-stale .tab-badge {
+    color: var(--muted);
+    animation: stale-pulse 1.8s ease-in-out infinite;
+  }
+  .main:not(.data-stale) .stat .v,
+  .main:not(.data-stale) .tab-badge {
+    animation: none;
+    transition: color 0.5s ease, opacity 0.5s ease;
+  }

--- a/src/styles/views.css
+++ b/src/styles/views.css
@@ -12,6 +12,8 @@
     gap: 12px;
     margin-bottom: 14px;
     flex-wrap: wrap;
+    min-width: 0;
+    max-width: 100%;
   }
 
   .stats {
@@ -497,7 +499,7 @@
     .pagination .page-btn { min-width: 30px; padding: 0 8px; }
   }
 
-  .view-issues, .view-repos, .view-kanban, .view-digests { display: none; }
+  .view-issues, .view-repos, .view-kanban, .view-digests { display: none; min-width: 0; }
   body.tab-issues .view-issues { display: block; }
   body.tab-repos  .view-repos  { display: block; }
   body.tab-kanban .view-kanban { display: block; }

--- a/src/utils/filtersCache.ts
+++ b/src/utils/filtersCache.ts
@@ -1,0 +1,216 @@
+/**
+ * Persists sidebar filter selections to localStorage so they survive page refreshes.
+ * Follows the same pattern as statsCache.ts — pure functions, shape validation, silent failure.
+ */
+
+import type { IssueFilters, PullRequestFilters, RepoFilters } from "./dashboard";
+
+const STORAGE_KEY = "gh-dash.cache.filters";
+
+/** JSON-safe representation (Sets become arrays). */
+export interface CachedFilters {
+  repoFilters: {
+    search: string;
+    orgs: string[];
+    languages: string[];
+    visibility: string;
+    includeForks: boolean;
+    includeArchived: boolean;
+  };
+  issueFilters: {
+    search: string;
+    orgs: string[];
+    repos: string[];
+    labels: string[];
+    authors: string[];
+    assignees: string[];
+    dates: { cf: string; ct: string; uf: string; ut: string };
+    preset: string;
+  };
+  prFilters: {
+    search: string;
+    orgs: string[];
+    repos: string[];
+    labels: string[];
+    authors: string[];
+    assignees: string[];
+    dates: { cf: string; ct: string; uf: string; ut: string };
+    preset: string;
+  };
+  savedAt: number;
+}
+
+const VALID_VISIBILITY = new Set(["all", "public", "private"]);
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isDateFilters(value: unknown): value is { cf: string; ct: string; uf: string; ut: string } {
+  if (!value || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj.cf === "string" && typeof obj.ct === "string" && typeof obj.uf === "string" && typeof obj.ut === "string";
+}
+
+function validateShape(parsed: unknown): parsed is CachedFilters {
+  if (!parsed || typeof parsed !== "object") return false;
+  const obj = parsed as Record<string, unknown>;
+
+  // Validate repoFilters
+  const rf = obj.repoFilters;
+  if (!rf || typeof rf !== "object") return false;
+  const repoF = rf as Record<string, unknown>;
+  if (typeof repoF.search !== "string") return false;
+  if (!isStringArray(repoF.orgs)) return false;
+  if (!isStringArray(repoF.languages)) return false;
+  if (typeof repoF.visibility !== "string") return false;
+  if (typeof repoF.includeForks !== "boolean") return false;
+  if (typeof repoF.includeArchived !== "boolean") return false;
+
+  // Validate issueFilters
+  const isf = obj.issueFilters;
+  if (!isf || typeof isf !== "object") return false;
+  const issueF = isf as Record<string, unknown>;
+  if (typeof issueF.search !== "string") return false;
+  if (!isStringArray(issueF.orgs)) return false;
+  if (!isStringArray(issueF.repos)) return false;
+  if (!isStringArray(issueF.labels)) return false;
+  if (!isStringArray(issueF.authors)) return false;
+  if (!isStringArray(issueF.assignees)) return false;
+  if (!isDateFilters(issueF.dates)) return false;
+  if (typeof issueF.preset !== "string") return false;
+
+  // Validate prFilters
+  const prf = obj.prFilters;
+  if (!prf || typeof prf !== "object") return false;
+  const prF = prf as Record<string, unknown>;
+  if (typeof prF.search !== "string") return false;
+  if (!isStringArray(prF.orgs)) return false;
+  if (!isStringArray(prF.repos)) return false;
+  if (!isStringArray(prF.labels)) return false;
+  if (!isStringArray(prF.authors)) return false;
+  if (!isStringArray(prF.assignees)) return false;
+  if (!isDateFilters(prF.dates)) return false;
+  if (typeof prF.preset !== "string") return false;
+
+  return true;
+}
+
+/**
+ * Read cached filters from localStorage.
+ * Returns null if no cache exists, data is unparseable, or shape is invalid.
+ */
+export function readFiltersCache(): CachedFilters | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!validateShape(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert cached JSON-safe filters back to the Set-based types used by the app.
+ * Sanitizes invalid visibility values.
+ */
+export function hydrateFilters(cached: CachedFilters): {
+  repoFilters: RepoFilters;
+  issueFilters: IssueFilters;
+  prFilters: PullRequestFilters;
+} {
+  const visibility = VALID_VISIBILITY.has(cached.repoFilters.visibility)
+    ? (cached.repoFilters.visibility as "all" | "public" | "private")
+    : "all";
+
+  return {
+    repoFilters: {
+      search: cached.repoFilters.search,
+      orgs: new Set(cached.repoFilters.orgs),
+      languages: new Set(cached.repoFilters.languages),
+      visibility,
+      includeForks: cached.repoFilters.includeForks,
+      includeArchived: cached.repoFilters.includeArchived,
+    },
+    issueFilters: {
+      search: cached.issueFilters.search,
+      orgs: new Set(cached.issueFilters.orgs),
+      repos: new Set(cached.issueFilters.repos),
+      labels: new Set(cached.issueFilters.labels),
+      authors: new Set(cached.issueFilters.authors),
+      assignees: new Set(cached.issueFilters.assignees),
+      dates: { ...cached.issueFilters.dates },
+      preset: cached.issueFilters.preset,
+    },
+    prFilters: {
+      search: cached.prFilters.search,
+      orgs: new Set(cached.prFilters.orgs),
+      repos: new Set(cached.prFilters.repos),
+      labels: new Set(cached.prFilters.labels),
+      authors: new Set(cached.prFilters.authors),
+      assignees: new Set(cached.prFilters.assignees),
+      dates: { ...cached.prFilters.dates },
+      preset: cached.prFilters.preset,
+    },
+  };
+}
+
+/**
+ * Write current filter state to localStorage. Silently fails on quota errors.
+ * Converts Sets to arrays for JSON serialization.
+ */
+export function writeFiltersCache(
+  repoFilters: RepoFilters,
+  issueFilters: IssueFilters,
+  prFilters: PullRequestFilters,
+): void {
+  try {
+    const entry: CachedFilters = {
+      repoFilters: {
+        search: repoFilters.search,
+        orgs: [...repoFilters.orgs],
+        languages: [...repoFilters.languages],
+        visibility: repoFilters.visibility,
+        includeForks: repoFilters.includeForks,
+        includeArchived: repoFilters.includeArchived,
+      },
+      issueFilters: {
+        search: issueFilters.search,
+        orgs: [...issueFilters.orgs],
+        repos: [...issueFilters.repos],
+        labels: [...issueFilters.labels],
+        authors: [...issueFilters.authors],
+        assignees: [...issueFilters.assignees],
+        dates: { ...issueFilters.dates },
+        preset: issueFilters.preset,
+      },
+      prFilters: {
+        search: prFilters.search,
+        orgs: [...prFilters.orgs],
+        repos: [...prFilters.repos],
+        labels: [...prFilters.labels],
+        authors: [...prFilters.authors],
+        assignees: [...prFilters.assignees],
+        dates: { ...prFilters.dates },
+        preset: prFilters.preset,
+      },
+      savedAt: Date.now(),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+  } catch {
+    // Quota exceeded or private browsing — ignore silently
+  }
+}
+
+/**
+ * Remove cached filters (e.g. on logout or "Clear all" reset).
+ */
+export function clearFiltersCache(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore
+  }
+}

--- a/src/utils/filtersCache.ts
+++ b/src/utils/filtersCache.ts
@@ -37,6 +37,12 @@ export interface CachedFilters {
     dates: { cf: string; ct: string; uf: string; ut: string };
     preset: string;
   };
+  // Optional so cached data from before this field existed still validates.
+  sorts?: {
+    issueSort: string;
+    prSort: string;
+    repoSort: string;
+  };
   savedAt: number;
 }
 
@@ -114,7 +120,11 @@ export function readFiltersCache(): CachedFilters | null {
 
 /**
  * Convert cached JSON-safe filters back to the Set-based types used by the app.
- * Sanitizes invalid visibility values.
+ * Sanitizes invalid visibility values to "all".
+ *
+ * Stale org/language references (orgs that no longer exist in the user's data)
+ * are kept in the Sets — the existing filter logic in App.tsx intersects them
+ * with the current facets, so non-matching entries simply produce 0 results.
  */
 export function hydrateFilters(cached: CachedFilters): {
   repoFilters: RepoFilters;
@@ -165,6 +175,7 @@ export function writeFiltersCache(
   repoFilters: RepoFilters,
   issueFilters: IssueFilters,
   prFilters: PullRequestFilters,
+  sorts?: { issueSort: string; prSort: string; repoSort: string },
 ): void {
   try {
     const entry: CachedFilters = {
@@ -196,6 +207,7 @@ export function writeFiltersCache(
         dates: { ...prFilters.dates },
         preset: prFilters.preset,
       },
+      sorts: sorts ? { ...sorts } : undefined,
       savedAt: Date.now(),
     };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));

--- a/src/utils/statsCache.ts
+++ b/src/utils/statsCache.ts
@@ -5,6 +5,8 @@
 
 const STORAGE_PREFIX = "gh-dash.cache.";
 
+// Arrays typed as unknown[] to avoid coupling this module to the full GitHub types.
+// The consumer casts them back (e.g. `as GhRepo[]`) — the cache is just a pass-through.
 export interface CachedStats {
   repos: unknown[];
   owners: string[];

--- a/src/utils/statsCache.ts
+++ b/src/utils/statsCache.ts
@@ -1,0 +1,59 @@
+/**
+ * Persists dashboard API responses to localStorage so that subsequent page
+ * loads can display last-known values immediately (avoiding a flash of zeros).
+ */
+
+const STORAGE_PREFIX = "gh-dash.cache.";
+
+export interface CachedStats {
+  repos: unknown[];
+  owners: string[];
+  issues: unknown[];
+  pullRequests: unknown[];
+  fetchedAt: string;
+  savedAt: number;
+}
+
+const STATS_KEY = `${STORAGE_PREFIX}stats`;
+
+/**
+ * Read cached stats from localStorage.
+ * Returns null if no cache exists or if the data is unparseable.
+ */
+export function readStatsCache(): CachedStats | null {
+  try {
+    const raw = localStorage.getItem(STATS_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CachedStats;
+    // Basic shape validation
+    if (!Array.isArray(parsed.repos) || !Array.isArray(parsed.issues) || !Array.isArray(parsed.pullRequests)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write stats to localStorage. Silently fails on quota errors.
+ */
+export function writeStatsCache(data: Omit<CachedStats, "savedAt">): void {
+  try {
+    const entry: CachedStats = { ...data, savedAt: Date.now() };
+    localStorage.setItem(STATS_KEY, JSON.stringify(entry));
+  } catch {
+    // Quota exceeded or private browsing — ignore silently
+  }
+}
+
+/**
+ * Remove cached stats (e.g. on logout or account switch).
+ */
+export function clearStatsCache(): void {
+  try {
+    localStorage.removeItem(STATS_KEY);
+  } catch {
+    // Ignore
+  }
+}

--- a/tests/utils/filtersCache.test.ts
+++ b/tests/utils/filtersCache.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearFiltersCache,
+  hydrateFilters,
+  readFiltersCache,
+  writeFiltersCache,
+} from "../../src/utils/filtersCache";
+
+function makeDefaultRepoFilters() {
+  return { search: "", orgs: new Set<string>(), languages: new Set<string>(), visibility: "all" as const, includeForks: true, includeArchived: false };
+}
+
+function makeDefaultIssueFilters() {
+  return { search: "", orgs: new Set<string>(), repos: new Set<string>(), labels: new Set<string>(), authors: new Set<string>(), assignees: new Set<string>(), dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" };
+}
+
+function makeDefaultPrFilters() {
+  return { search: "", orgs: new Set<string>(), repos: new Set<string>(), labels: new Set<string>(), authors: new Set<string>(), assignees: new Set<string>(), dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" };
+}
+
+describe("filtersCache", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when no cache exists", () => {
+    expect(readFiltersCache()).toBeNull();
+  });
+
+  it("round-trips write then read", () => {
+    const repo = { ...makeDefaultRepoFilters(), orgs: new Set(["acme"]), languages: new Set(["Go"]), visibility: "private" as const };
+    const issue = { ...makeDefaultIssueFilters(), search: "bug", orgs: new Set(["acme"]) };
+    const pr = { ...makeDefaultPrFilters(), preset: "draft" };
+
+    writeFiltersCache(repo, issue, pr);
+    const result = readFiltersCache();
+
+    expect(result).not.toBeNull();
+    expect(result!.repoFilters.orgs).toEqual(["acme"]);
+    expect(result!.repoFilters.languages).toEqual(["Go"]);
+    expect(result!.repoFilters.visibility).toBe("private");
+    expect(result!.issueFilters.search).toBe("bug");
+    expect(result!.issueFilters.orgs).toEqual(["acme"]);
+    expect(result!.prFilters.preset).toBe("draft");
+    expect(result!.savedAt).toBeGreaterThan(0);
+  });
+
+  it("hydrates cached JSON back to Set-based filter types", () => {
+    const repo = { ...makeDefaultRepoFilters(), orgs: new Set(["org1", "org2"]), languages: new Set(["TypeScript"]) };
+    writeFiltersCache(repo, makeDefaultIssueFilters(), makeDefaultPrFilters());
+
+    const cached = readFiltersCache()!;
+    const hydrated = hydrateFilters(cached);
+
+    expect(hydrated.repoFilters.orgs).toBeInstanceOf(Set);
+    expect(hydrated.repoFilters.orgs.has("org1")).toBe(true);
+    expect(hydrated.repoFilters.orgs.has("org2")).toBe(true);
+    expect(hydrated.repoFilters.languages.has("TypeScript")).toBe(true);
+  });
+
+  it("returns null for corrupted JSON", () => {
+    localStorage.setItem("gh-dash.cache.filters", "not-json{{{");
+    expect(readFiltersCache()).toBeNull();
+  });
+
+  it("returns null for invalid shape (missing repoFilters)", () => {
+    localStorage.setItem("gh-dash.cache.filters", JSON.stringify({
+      issueFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      prFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      savedAt: 1,
+    }));
+    expect(readFiltersCache()).toBeNull();
+  });
+
+  it("returns null for partial corruption (orgs is not an array)", () => {
+    localStorage.setItem("gh-dash.cache.filters", JSON.stringify({
+      repoFilters: { search: "", orgs: "not-array", languages: [], visibility: "all", includeForks: true, includeArchived: false },
+      issueFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      prFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      savedAt: 1,
+    }));
+    expect(readFiltersCache()).toBeNull();
+  });
+
+  it("returns null when dates field has wrong shape", () => {
+    localStorage.setItem("gh-dash.cache.filters", JSON.stringify({
+      repoFilters: { search: "", orgs: [], languages: [], visibility: "all", includeForks: true, includeArchived: false },
+      issueFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: "bad", preset: "" },
+      prFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      savedAt: 1,
+    }));
+    expect(readFiltersCache()).toBeNull();
+  });
+
+  it("handles localStorage quota errors gracefully on write", () => {
+    const originalSetItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new DOMException("QuotaExceededError");
+    };
+
+    expect(() => writeFiltersCache(
+      makeDefaultRepoFilters(),
+      makeDefaultIssueFilters(),
+      makeDefaultPrFilters(),
+    )).not.toThrow();
+
+    Storage.prototype.setItem = originalSetItem;
+  });
+
+  it("sanitizes invalid visibility to 'all' during hydration", () => {
+    localStorage.setItem("gh-dash.cache.filters", JSON.stringify({
+      repoFilters: { search: "", orgs: [], languages: [], visibility: "bogus", includeForks: true, includeArchived: false },
+      issueFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      prFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      savedAt: 1,
+    }));
+
+    const cached = readFiltersCache()!;
+    const hydrated = hydrateFilters(cached);
+    expect(hydrated.repoFilters.visibility).toBe("all");
+  });
+
+  it("stale org references do not crash hydration", () => {
+    localStorage.setItem("gh-dash.cache.filters", JSON.stringify({
+      repoFilters: { search: "", orgs: ["org-that-no-longer-exists", "still-valid"], languages: ["Haskell"], visibility: "all", includeForks: true, includeArchived: false },
+      issueFilters: { search: "", orgs: ["ghost-org"], repos: ["ghost/repo"], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      prFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      savedAt: 1,
+    }));
+
+    const cached = readFiltersCache()!;
+    const hydrated = hydrateFilters(cached);
+    expect(hydrated.repoFilters.orgs.has("org-that-no-longer-exists")).toBe(true);
+    expect(hydrated.repoFilters.orgs.has("still-valid")).toBe(true);
+    expect(hydrated.issueFilters.orgs.has("ghost-org")).toBe(true);
+  });
+
+  it("clears cached filters", () => {
+    writeFiltersCache(makeDefaultRepoFilters(), makeDefaultIssueFilters(), makeDefaultPrFilters());
+    clearFiltersCache();
+    expect(readFiltersCache()).toBeNull();
+  });
+
+  it("overwrites previous cache on second write", () => {
+    writeFiltersCache(
+      { ...makeDefaultRepoFilters(), orgs: new Set(["old-org"]) },
+      makeDefaultIssueFilters(),
+      makeDefaultPrFilters(),
+    );
+
+    writeFiltersCache(
+      { ...makeDefaultRepoFilters(), orgs: new Set(["new-org"]) },
+      makeDefaultIssueFilters(),
+      makeDefaultPrFilters(),
+    );
+
+    const result = readFiltersCache()!;
+    expect(result.repoFilters.orgs).toEqual(["new-org"]);
+  });
+
+  it("returns null when includeForks is not a boolean", () => {
+    localStorage.setItem("gh-dash.cache.filters", JSON.stringify({
+      repoFilters: { search: "", orgs: [], languages: [], visibility: "all", includeForks: "yes", includeArchived: false },
+      issueFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      prFilters: { search: "", orgs: [], repos: [], labels: [], authors: [], assignees: [], dates: { cf: "", ct: "", uf: "", ut: "" }, preset: "" },
+      savedAt: 1,
+    }));
+    expect(readFiltersCache()).toBeNull();
+  });
+});

--- a/tests/utils/statsCache.test.ts
+++ b/tests/utils/statsCache.test.ts
@@ -75,4 +75,38 @@ describe("statsCache", () => {
 
     Storage.prototype.setItem = originalSetItem;
   });
+
+  it("overwrites previous cache on second write", () => {
+    writeStatsCache({
+      repos: [{ name: "old" }],
+      owners: ["old-owner"],
+      issues: [],
+      pullRequests: [],
+      fetchedAt: "2026-01-01T00:00:00Z",
+    });
+
+    writeStatsCache({
+      repos: [{ name: "new" }],
+      owners: ["new-owner"],
+      issues: [{ title: "Fresh" }],
+      pullRequests: [],
+      fetchedAt: "2026-05-03T00:00:00Z",
+    });
+
+    const result = readStatsCache();
+    expect(result!.repos).toEqual([{ name: "new" }]);
+    expect(result!.owners).toEqual(["new-owner"]);
+    expect(result!.issues).toEqual([{ title: "Fresh" }]);
+    expect(result!.fetchedAt).toBe("2026-05-03T00:00:00Z");
+  });
+
+  it("returns null if required arrays are missing", () => {
+    localStorage.setItem("gh-dash.cache.stats", JSON.stringify({
+      repos: [{ name: "ok" }],
+      owners: ["owner"],
+      fetchedAt: "2026-01-01",
+      savedAt: 1,
+    }));
+    expect(readStatsCache()).toBeNull();
+  });
 });

--- a/tests/utils/statsCache.test.ts
+++ b/tests/utils/statsCache.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearStatsCache, readStatsCache, writeStatsCache } from "../../src/utils/statsCache";
+
+describe("statsCache", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when no cache exists", () => {
+    expect(readStatsCache()).toBeNull();
+  });
+
+  it("writes and reads back cached stats", () => {
+    const data = {
+      repos: [{ nameWithOwner: "acme/app", stargazerCount: 10 }],
+      owners: ["acme"],
+      issues: [{ title: "Bug" }],
+      pullRequests: [{ title: "Fix" }],
+      fetchedAt: "2026-04-29T10:00:00Z",
+    };
+
+    writeStatsCache(data);
+    const result = readStatsCache();
+
+    expect(result).not.toBeNull();
+    expect(result!.repos).toEqual(data.repos);
+    expect(result!.owners).toEqual(data.owners);
+    expect(result!.issues).toEqual(data.issues);
+    expect(result!.pullRequests).toEqual(data.pullRequests);
+    expect(result!.fetchedAt).toBe(data.fetchedAt);
+    expect(result!.savedAt).toBeGreaterThan(0);
+  });
+
+  it("clears cached stats", () => {
+    writeStatsCache({
+      repos: [],
+      owners: [],
+      issues: [],
+      pullRequests: [],
+      fetchedAt: "",
+    });
+
+    clearStatsCache();
+    expect(readStatsCache()).toBeNull();
+  });
+
+  it("returns null for corrupted JSON", () => {
+    localStorage.setItem("gh-dash.cache.stats", "not-json{{{");
+    expect(readStatsCache()).toBeNull();
+  });
+
+  it("returns null if data shape is invalid", () => {
+    localStorage.setItem("gh-dash.cache.stats", JSON.stringify({ repos: "not-array" }));
+    expect(readStatsCache()).toBeNull();
+  });
+
+  it("handles localStorage quota errors gracefully", () => {
+    const originalSetItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new DOMException("QuotaExceededError");
+    };
+
+    // Should not throw
+    expect(() => writeStatsCache({
+      repos: [],
+      owners: [],
+      issues: [],
+      pullRequests: [],
+      fetchedAt: "",
+    })).not.toThrow();
+
+    Storage.prototype.setItem = originalSetItem;
+  });
+});


### PR DESCRIPTION
## Problem

Three UX issues that compound on daily use:

1. **Flash of zeros on refresh** — all stat counters show `0` until the API responds
2. **Filters reset on every refresh** — sidebar selections (orgs, languages, visibility, sort order) don't survive page reloads
3. **Horizontal overflow** — page overflows at intermediate viewport widths (~960-1128px); tabs overflow on mobile

## Solution

### localStorage persistence

Two new utility modules (`statsCache.ts`, `filtersCache.ts`) cache API data and filter state to `localStorage`. On page load, cached values are shown immediately; when the API responds, fresh data replaces them. A subtle pulse animation on stat values signals "cached data loading..."

All operations are wrapped in try/catch — if `localStorage` is disabled, full, or corrupted, the app behaves exactly as before. Shape validation on read ensures corrupted data is silently discarded. The filter cache is read and hydrated once on mount and shared across all filter/sort state initializers (single parse, no redundant reads).

### Responsive fixes

Added `grid-template-columns: minmax(0, 1fr)` to `.main` to prevent implicit grid track overflow. On mobile (≤640px), tabs collapse to icon-only with a smooth expand-on-hover animation.

### UX polish

User's GitHub avatar shown in top bar. Theme/Refresh button label borders cleaned up.

## Files changed

| File | Change |
|------|--------|
| `src/utils/statsCache.ts` | **New** — cache API response data |
| `src/utils/filtersCache.ts` | **New** — cache sidebar filters (orgs, languages, visibility, forks, archived, search, dates, presets) and sort order (issue/PR/repo) |
| `tests/utils/statsCache.test.ts` | **New** — 8 tests |
| `tests/utils/filtersCache.test.ts` | **New** — 13 tests |
| `src/App.tsx` | Seed stats, filters, and sort order from cache on mount; persist on change; clear on logout and "Clear all" |
| `src/components/TopBar.tsx` | User avatar |
| `src/styles/views.css` | Grid overflow fix, stale pulse animation |
| `src/styles/navigation.css` | Responsive tabs, avatar, button borders |
| `src/styles/base.css` | `overflow-x: hidden` on body |

## Test plan

- [x] `npm test` — 55 tests pass (34 existing + 21 new)
- [x] `npm run build` — clean
- [ ] Manual: refresh → stats persist, filters persist, sort persists
- [ ] Manual: "Clear all" → defaults restored
- [ ] Manual: resize 1280→960→640→390px → no horizontal overflow
- [ ] Manual: mobile tabs → icon-only, hover reveals label