### PR TITLE
chore: add COPY CHANGELOG.md ./ to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY tsconfig.json vite.config.ts index.html ./
+COPY CHANGELOG.md ./
 COPY src ./src
 COPY public ./public
 


### PR DESCRIPTION
## Problem

I failed to run `docker compose up -d --build`

```
 => ERROR [builder 8/8] RUN npm run build                                                                                                                   0.4s 
------                                                                                                                                                           
 > [builder 8/8] RUN npm run build:
0.154 
0.154 > gh-issues-dashboard@1.0.1 build
0.154 > esbuild src/server.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/server.js && vite build
0.154 
0.165 
0.165   dist/server.js  86.6kb
0.165 
0.165 ⚡ Done in 6ms
0.318 vite v8.0.9 building client environment for production...
transforming...✓ 58 modules transformed.
0.414 ✗ Build failed in 95ms
0.415 error during build:
0.415 Build failed with 1 error:
0.415 
0.415 [UNRESOLVED_IMPORT] Error: Could not resolve '../../../CHANGELOG.md?raw' in src/components/modals/ChangelogModal.tsx
0.415    ╭─[ src/components/modals/ChangelogModal.tsx:2:29 ]
0.415    │
0.415  2 │ import changelogSource from "../../../CHANGELOG.md?raw";
0.415    │                             ─────────────┬─────────────  
0.415    │                                          ╰─────────────── Module not found.
0.415    │ 
0.415    │ Help: 'src/components/modals/ChangelogModal.tsx' is imported by the following path:
0.415    │         - src/components/modals/ChangelogModal.tsx
0.415    │         - src/App.tsx
0.415    │         - src/main.tsx
0.415    │         - index.html
0.415 ───╯
0.415 
0.415     at aggregateBindingErrorsIntoJsError (file:///app/node_modules/rolldown/dist/shared/error-DAA7ncC5.mjs:48:18)
0.415     at unwrapBindingResult (file:///app/node_modules/rolldown/dist/shared/error-DAA7ncC5.mjs:18:128)
0.415     at #build (file:///app/node_modules/rolldown/dist/shared/rolldown-build-BPKCFYpX.mjs:3317:34)
0.415     at async buildEnvironment (file:///app/node_modules/vite/dist/node/chunks/node.js:32999:64)
0.415     at async Object.build (file:///app/node_modules/vite/dist/node/chunks/node.js:33421:19)
0.415     at async Object.buildApp (file:///app/node_modules/vite/dist/node/chunks/node.js:33418:153)
0.415     at async CAC.<anonymous> (file:///app/node_modules/vite/dist/node/cli.js:778:3) {
0.415   errors: [Getter/Setter]
0.415 }
------
```

Your file:
```
src/components/modals/ChangelogModal.tsx
```

contains:
```
import changelogSource from "../../../CHANGELOG.md?raw";
```

That means during vite build, Vite must find this file:
```
/app/CHANGELOG.md
```

But inside Docker, your Dockerfile only copies:
```
COPY package.json package-lock.json ./
COPY tsconfig.json vite.config.ts index.html ./
COPY src ./src
COPY public ./public
```

So CHANGELOG.md was never copied into container.

## Solution

### Copy CHANGELOG.md in Dockerfile

Add this before build:
```
COPY CHANGELOG.md ./
```

Example:
```
COPY package.json package-lock.json ./
RUN npm ci

COPY tsconfig.json vite.config.ts index.html ./
COPY CHANGELOG.md ./
COPY src ./src
COPY public ./public

RUN npm run build
```

## Files changed

| File | Change |
|------|--------|
| `Dockerfile` | Add COPY CHANGELOG.md ./ |

## Test plan

- [x] `docker compose up -d --build` — passed