### PR TITLE
fix(sidebar): keep filter sections open after deselecting the last item

### DIFF
--- a/src/components/SidebarControls.tsx
+++ b/src/components/SidebarControls.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { FacetValue, IssueFilters, PullRequestFilters, RepoFilters } from "../utils/dashboard";
 import { getLanguageColor } from "../utils/colors";
 import { INBOX_MAILBOXES, type InboxMailbox } from "../utils/inbox";
@@ -108,9 +108,30 @@ function CheckList({
 
 function FilterSection({ title, activeCount, children, dataFor, open = false, onClear }: { title: string; activeCount: number; children: ReactNode; dataFor?: string; open?: boolean; onClear?: () => void }) {
   const { t } = useI18n();
+  const [isOpen, setIsOpen] = useState(open || activeCount > 0);
+  const prevActiveCountRef = useRef(activeCount);
+  // Auto-open when filters become active, but never auto-close — the user may
+  // want to deselect the last item and pick a different one without the panel
+  // collapsing on them (issue #12). Sections passed `open` (Organizations,
+  // Visibility, Options) stay pinned open as before.
+  useEffect(() => {
+    const prev = prevActiveCountRef.current;
+    prevActiveCountRef.current = activeCount;
+    if (prev === 0 && activeCount > 0) setIsOpen(true);
+  }, [activeCount]);
+  const effectiveOpen = open || isOpen;
   const clearable = activeCount > 0 && Boolean(onClear);
   return (
-    <details className="section" data-for={dataFor} open={open || activeCount > 0}>
+    <details
+      className="section"
+      data-for={dataFor}
+      open={effectiveOpen}
+      onToggle={(event) => {
+        const next = (event.currentTarget as HTMLDetailsElement).open;
+        if (open && !next) return;
+        setIsOpen(next);
+      }}
+    >
       <summary>
         <ChevronIcon />
         {title}


### PR DESCRIPTION
Closes #12.

## Summary
- The `FilterSection` `<details>` element was controlled by `open || activeCount > 0`. As soon as the user deselected the last selected entry, React re-rendered with `open={false}` and the section collapsed — even though the user was likely about to pick a different value.
- Move open/closed state into local state inside `FilterSection`:
  - initialise from the existing `open || activeCount > 0` rule (so saved filters still expand the section on mount);
  - auto-open on the `0 → N` transition (e.g. a preset that adds filters at runtime);
  - never auto-close — the user keeps control of the panel;
  - sections passed `open` (Organizations, Visibility, Options) stay pinned open as before, since they host always-visible toggles.

## Test plan
- [x] On Issues / PRs, expand `Repositories` (or `Labels`, `Authors`, `Assignees`), select 2+ entries, then deselect them one by one — the section must stay expanded after the last deselection.
- [ ] Manually collapse a section via its summary — it stays collapsed; toggling a checkbox in another section doesn't reopen it.
- [ ] Apply a filter preset that adds selections to a previously empty section — the section auto-expands.
- [ ] On Repositories, `Visibility` and `Options` remain pinned open (they're always-on toggles).
- [ ] Reload the page with persisted filters — affected sections start expanded.