### PR TITLE
Update Docker build platforms

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.ref != 'refs/heads/main' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
Removed support for linux/arm/v7 platform in Docker build.

Ti ho tolto linux/arm/v7 perché vecchio e perché bisognerebbe fare alcune modifiche al Dockerfile per poterlo rendere ancora compatibile ed evitare che vada in errore l'action di build e publish. Considerato che cosa c'è ormai in giro, direi che non è una grave perdita (semplicemente si lavora su macchine ormai a 64 bit).