### PR TITLE
Always push and login in dockerbuild workflow

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -40,7 +40,6 @@ jobs:
         run: echo ${{ steps.buildx.outputs.platforms }}
 
       - name: Login to GHCR
-        if: github.ref != 'refs/heads/main'
         uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
@@ -53,7 +52,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: ${{ github.ref != 'refs/heads/main' }}
+          platforms: linux/amd64,linux/arm64
+          push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
Remove the conditional GHCR login so the workflow logs into ghcr.io for all refs, set build platforms to linux/amd64 and linux/arm64 (dropping linux/arm/v7), and enable image push unconditionally (push: true). These changes simplify the workflow and ensure images are pushed for the configured platforms on every run.

Ti ho tolto linux/arm/v7 perché vecchio e perché bisognerebbe fare alcune modifiche al Dockerfile per poterlo rendere ancora compatibile ed evitare che vada in errore l'action di build e publish. Considerato che cosa c'è ormai in giro, direi che non è una grave perdita (semplicemente si lavora su macchine ormai a 64 bit).

Questa sostituisce la precedente https://github.com/debba/gitdeck/pull/20