### PR TITLE
Use full repo path for Docker image

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -24,7 +24,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v6.0.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/gh-dashboard
+          images: ghcr.io/${{ github.repository }}
           tags: |
             latest
             ${{ github.ref_name }}


### PR DESCRIPTION
Replace hardcoded ghcr.io/${{ github.repository_owner }}/gh-dashboard with ghcr.io/${{ github.repository }} so the image uses the current owner/repository path. This ensures the workflow publishes the image under the correct repository instead of a fixed repository name.