### PR TITLE
fix: load bot and GitHub App avatars from the API avatar URL

### DIFF
--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -1,11 +1,15 @@
 interface AvatarProps {
   login?: string;
+  avatarUrl?: string | null;
   size?: number;
   className?: string;
 }
 
-export function Avatar({ login, size = 36, className }: AvatarProps) {
-  const url = login ? `https://github.com/${encodeURIComponent(login)}.png?size=${size * 2}` : null;
+export function Avatar({ login, avatarUrl, size = 36, className }: AvatarProps) {
+  // Prefer the provider-supplied avatar URL: reconstructing `https://github.com/<login>.png`
+  // does not resolve for GitHub App / bot accounts (their avatars live at
+  // avatars.githubusercontent.com/in/<app_id>). Fall back to the login-derived URL.
+  const url = avatarUrl || (login ? `https://github.com/${encodeURIComponent(login)}.png?size=${size * 2}` : null);
   const initials = (login || "?").slice(0, 1).toUpperCase();
   return (
     <span

--- a/src/components/views/IssueList.tsx
+++ b/src/components/views/IssueList.tsx
@@ -18,7 +18,7 @@ export function IssueList({ issues }: { issues: GhIssue[] }) {
         const author = issue.author?.login || "unknown";
         return (
           <a className="data-row" href={issue.url} key={issue.url} target="_blank" rel="noreferrer">
-            <Avatar login={issue.author?.login} size={36} />
+            <Avatar login={issue.author?.login} avatarUrl={issue.author?.avatarUrl} size={36} />
             <div className="data-row-body">
               <div className="data-row-top">
                 <strong className="data-row-author">{author}</strong>
@@ -50,7 +50,7 @@ export function IssueList({ issues }: { issues: GhIssue[] }) {
                 {issue.assignees && issue.assignees.length ? (
                   <span className="data-row-assignees">
                     {issue.assignees.slice(0, 3).map((assignee) => (
-                      <Avatar key={assignee.login} login={assignee.login} size={18} />
+                      <Avatar key={assignee.login} login={assignee.login} avatarUrl={assignee.avatarUrl} size={18} />
                     ))}
                   </span>
                 ) : null}

--- a/src/components/views/PullRequestList.tsx
+++ b/src/components/views/PullRequestList.tsx
@@ -25,7 +25,7 @@ export function PullRequestList({ pullRequests }: { pullRequests: GhPullRequest[
         const author = pr.author?.login || "unknown";
         return (
           <a className="data-row" href={pr.url} key={pr.url} target="_blank" rel="noreferrer">
-            <Avatar login={pr.author?.login} size={36} />
+            <Avatar login={pr.author?.login} avatarUrl={pr.author?.avatarUrl} size={36} />
             <div className="data-row-body">
               <div className="data-row-top">
                 <strong className="data-row-author">{author}</strong>
@@ -60,7 +60,7 @@ export function PullRequestList({ pullRequests }: { pullRequests: GhPullRequest[
                 {pr.assignees && pr.assignees.length ? (
                   <span className="data-row-assignees">
                     {pr.assignees.slice(0, 3).map((assignee) => (
-                      <Avatar key={assignee.login} login={assignee.login} size={18} />
+                      <Avatar key={assignee.login} login={assignee.login} avatarUrl={assignee.avatarUrl} size={18} />
                     ))}
                   </span>
                 ) : null}

--- a/src/components/views/RepoGrid.tsx
+++ b/src/components/views/RepoGrid.tsx
@@ -39,7 +39,7 @@ export function RepoGrid({ repos, issues, insightsByRepo, onRepoClick, onIssuesC
             }}
           >
             <div className="rc-head">
-              <Avatar login={repo.owner.login} size={28} />
+              <Avatar login={repo.owner.login} avatarUrl={repo.owner.avatarUrl} size={28} />
               <div className="rc-title">
                 <a href={repo.url} target="_blank" rel="noreferrer" onClick={(event) => event.stopPropagation()}><span className="owner">{repo.owner.login}</span><span className="slash">/</span>{repo.name}</a>
               </div>

--- a/src/components/views/TriageWorkspace.tsx
+++ b/src/components/views/TriageWorkspace.tsx
@@ -123,7 +123,7 @@ function TriagePreview({ item, repo, onRepoClick, onMarkRead }: TriagePreviewPro
     <section className="inbox-reader">
       <header className="inbox-reader-head">
         <div className="inbox-reader-from">
-          <Avatar login={item.author?.login} size={48} />
+          <Avatar login={item.author?.login} avatarUrl={item.author?.avatarUrl} size={48} />
           <div className="inbox-reader-from-meta">
             <strong>{item.author?.login || "Unknown"}</strong>
             <span>
@@ -484,7 +484,7 @@ export function TriageWorkspace({
                 <span className="inbox-row-indicator" aria-hidden="true">
                   {item.unread ? <span className="inbox-row-dot" /> : null}
                 </span>
-                <Avatar login={item.author?.login} size={density === "compact" ? 28 : 36} />
+                <Avatar login={item.author?.login} avatarUrl={item.author?.avatarUrl} size={density === "compact" ? 28 : 36} />
                 <div className="inbox-row-body">
                   <div className="inbox-row-top">
                     <strong className="inbox-row-author">{item.author?.login || "Unknown"}</strong>

--- a/src/server/providers/github.ts
+++ b/src/server/providers/github.ts
@@ -522,7 +522,7 @@ query($q: String!, $cursor: String) {
       __typename
       ... on Issue {
         number title url createdAt updatedAt
-        author { login url }
+        author { login url avatarUrl }
         repository { name nameWithOwner }
         labels(first: 20) { nodes { name color description } }
         comments { totalCount }
@@ -542,7 +542,7 @@ query($q: String!, $cursor: String) {
       ... on PullRequest {
         number title url createdAt updatedAt
         isDraft reviewDecision
-        author { login url }
+        author { login url avatarUrl }
         repository { name nameWithOwner }
         labels(first: 20) { nodes { name color description } }
         comments { totalCount }
@@ -562,7 +562,7 @@ interface IssueSearchNode {
   url: string;
   createdAt: string;
   updatedAt: string;
-  author: { login: string; url: string } | null;
+  author: { login: string; url: string; avatarUrl?: string } | null;
   repository: { name: string; nameWithOwner: string };
   labels: { nodes: GhLabel[] };
   comments: { totalCount: number };
@@ -585,7 +585,7 @@ interface PullRequestSearchNode {
   updatedAt: string;
   isDraft: boolean;
   reviewDecision: ReviewDecision;
-  author: { login: string; url: string } | null;
+  author: { login: string; url: string; avatarUrl?: string } | null;
   repository: { name: string; nameWithOwner: string };
   labels: { nodes: GhLabel[] };
   comments: { totalCount: number };


### PR DESCRIPTION
Note: I used Claude Code to help me chase down the fix.

Avatars are built from the account login as `https://github.com/<login>.png`. That works for users and orgs, but not for GitHub App / bot accounts — e.g. a PR opened by `acme-ci` requests `https://github.com/acme-ci.png`, which 404s. Those avatars are actually served from `https://avatars.githubusercontent.com/in/<app_id>`.

The API already returns the correct `avatarUrl` for every account type, so this switches to using it and only falls back to the login-based URL when it's absent:

- `Avatar` takes an optional `avatarUrl` and prefers it
- the issue/PR search queries now request `avatarUrl` on `author` (assignees already had it)
- the issue list, PR list, triage, and repo grid pass it through

Tested against my own account — bot avatars now render where they were previously broken. `npm test` and `npm run build` pass.

### Before / After

| Before | After |
| --- | --- |
| <img width="109" height="233" alt="image" src="https://github.com/user-attachments/assets/aa07cbc8-4845-4335-bb18-9e6ae3a7fac7" />| <img width="110" height="244" alt="image" src="https://github.com/user-attachments/assets/ac0158ef-be0d-41d5-9ec3-0d10c53de7b3" /> |


