### PR TITLE
feat(preferences): hide archived repo noise from PRs, issues, insights and digests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "gh-issues-dashboard",
+  "name": "gitdeck",
   "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gh-issues-dashboard",
+      "name": "gitdeck",
       "version": "1.0.5",
       "dependencies": {
         "react": "^19.2.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ import {
   type RepoFilters,
 } from "./utils/dashboard";
 import { clampPage } from "./utils/pagination";
+import { getOwner } from "./utils/repository";
 import { formatNumber } from "./utils/format";
 import { clearStatsCache, readStatsCache, writeStatsCache } from "./utils/statsCache";
 import { clearFiltersCache, hydrateFilters, readFiltersCache, writeFiltersCache } from "./utils/filtersCache";
@@ -579,8 +580,22 @@ export function App() {
     () => (archivedRepoNames.size ? pullRequests.filter((pr) => !archivedRepoNames.has(pr.repository.nameWithOwner)) : pullRequests),
     [pullRequests, archivedRepoNames],
   );
-  const issueFacets = useMemo(() => buildIssueFacets(nonArchivedIssues), [nonArchivedIssues]);
-  const prFacets = useMemo(() => buildPullRequestFacets(nonArchivedPullRequests), [nonArchivedPullRequests]);
+  const issuesForFacets = useMemo(
+    () => (issueFilters.orgs.size ? nonArchivedIssues.filter((issue) => issueFilters.orgs.has(getOwner(issue.repository.nameWithOwner))) : nonArchivedIssues),
+    [nonArchivedIssues, issueFilters.orgs],
+  );
+  const pullRequestsForFacets = useMemo(
+    () => (prFilters.orgs.size ? nonArchivedPullRequests.filter((pr) => prFilters.orgs.has(getOwner(pr.repository.nameWithOwner))) : nonArchivedPullRequests),
+    [nonArchivedPullRequests, prFilters.orgs],
+  );
+  const issueFacets = useMemo(
+    () => ({ ...buildIssueFacets(issuesForFacets), orgs: buildIssueFacets(nonArchivedIssues).orgs }),
+    [issuesForFacets, nonArchivedIssues],
+  );
+  const prFacets = useMemo(
+    () => ({ ...buildPullRequestFacets(pullRequestsForFacets), orgs: buildPullRequestFacets(nonArchivedPullRequests).orgs }),
+    [pullRequestsForFacets, nonArchivedPullRequests],
+  );
   const repoFacets = useMemo(() => buildRepoFacets(repos), [repos]);
   const insightsByRepo = useMemo(() => new Map(repoInsights.map((insight) => [insight.repo, insight])), [repoInsights]);
   const filteredIssues = useMemo(() => sortIssues(filterIssues(nonArchivedIssues, issueFilters, userLogin), issueSort), [nonArchivedIssues, issueFilters, issueSort, userLogin]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -567,16 +567,24 @@ export function App() {
   }, [repoFilters, issueFilters, prFilters, issueSort, prSort, repoSort]);
 
   const userLogin = userLoginValue;
-  const issueFacets = useMemo(() => buildIssueFacets(issues), [issues]);
-  const prFacets = useMemo(() => buildPullRequestFacets(pullRequests), [pullRequests]);
-  const repoFacets = useMemo(() => buildRepoFacets(repos), [repos]);
-  const insightsByRepo = useMemo(() => new Map(repoInsights.map((insight) => [insight.repo, insight])), [repoInsights]);
   const archivedRepoNames = useMemo(
     () => (hideArchivedNoise ? new Set(repos.filter((repo) => repo.isArchived).map((repo) => repo.nameWithOwner)) : new Set<string>()),
     [repos, hideArchivedNoise],
   );
-  const filteredIssues = useMemo(() => sortIssues(filterIssues(issues, issueFilters, userLogin, archivedRepoNames), issueSort), [issues, issueFilters, issueSort, userLogin, archivedRepoNames]);
-  const filteredPullRequests = useMemo(() => sortPullRequests(filterPullRequests(pullRequests, prFilters, userLogin, archivedRepoNames), prSort), [pullRequests, prFilters, prSort, userLogin, archivedRepoNames]);
+  const nonArchivedIssues = useMemo(
+    () => (archivedRepoNames.size ? issues.filter((issue) => !archivedRepoNames.has(issue.repository.nameWithOwner)) : issues),
+    [issues, archivedRepoNames],
+  );
+  const nonArchivedPullRequests = useMemo(
+    () => (archivedRepoNames.size ? pullRequests.filter((pr) => !archivedRepoNames.has(pr.repository.nameWithOwner)) : pullRequests),
+    [pullRequests, archivedRepoNames],
+  );
+  const issueFacets = useMemo(() => buildIssueFacets(nonArchivedIssues), [nonArchivedIssues]);
+  const prFacets = useMemo(() => buildPullRequestFacets(nonArchivedPullRequests), [nonArchivedPullRequests]);
+  const repoFacets = useMemo(() => buildRepoFacets(repos), [repos]);
+  const insightsByRepo = useMemo(() => new Map(repoInsights.map((insight) => [insight.repo, insight])), [repoInsights]);
+  const filteredIssues = useMemo(() => sortIssues(filterIssues(nonArchivedIssues, issueFilters, userLogin), issueSort), [nonArchivedIssues, issueFilters, issueSort, userLogin]);
+  const filteredPullRequests = useMemo(() => sortPullRequests(filterPullRequests(nonArchivedPullRequests, prFilters, userLogin), prSort), [nonArchivedPullRequests, prFilters, prSort, userLogin]);
   const filteredRepos = useMemo(() => sortRepos(filterRepos(repos, issues, repoFilters), issues, repoSort, insightsByRepo), [repos, issues, repoFilters, repoSort, insightsByRepo]);
   const filteredInsights = useMemo(
     () => filteredRepos

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,6 +207,7 @@ export function App() {
   const [inboxSearch, setInboxSearch] = useState("");
   const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem("gh-dash.theme") as Theme) || "dark");
   const [textSize, setTextSize] = useState<TextSize>(() => (localStorage.getItem("gh-dash.textSize") as TextSize) || "normal");
+  const [hideArchivedNoise, setHideArchivedNoise] = useState(() => localStorage.getItem("gh-dash.hideArchivedNoise") !== "0");
   const [issueFilters, setIssueFilters] = useState<IssueFilters>(() => cachedFiltersOnMount?.hydrated.issueFilters ?? defaultIssueFilters());
   const [prFilters, setPrFilters] = useState<PullRequestFilters>(() => cachedFiltersOnMount?.hydrated.prFilters ?? defaultPrFilters());
   const [repoFilters, setRepoFilters] = useState<RepoFilters>(() => cachedFiltersOnMount?.hydrated.repoFilters ?? defaultRepoFilters());
@@ -446,6 +447,10 @@ export function App() {
   }, [textSize]);
 
   useEffect(() => {
+    localStorage.setItem("gh-dash.hideArchivedNoise", hideArchivedNoise ? "1" : "0");
+  }, [hideArchivedNoise]);
+
+  useEffect(() => {
     document.body.classList.toggle("tab-inbox", tab === "inbox");
     document.body.classList.toggle("tab-issues", tab === "issues");
     document.body.classList.toggle("tab-prs", tab === "prs");
@@ -566,8 +571,12 @@ export function App() {
   const prFacets = useMemo(() => buildPullRequestFacets(pullRequests), [pullRequests]);
   const repoFacets = useMemo(() => buildRepoFacets(repos), [repos]);
   const insightsByRepo = useMemo(() => new Map(repoInsights.map((insight) => [insight.repo, insight])), [repoInsights]);
-  const filteredIssues = useMemo(() => sortIssues(filterIssues(issues, issueFilters, userLogin), issueSort), [issues, issueFilters, issueSort, userLogin]);
-  const filteredPullRequests = useMemo(() => sortPullRequests(filterPullRequests(pullRequests, prFilters, userLogin), prSort), [pullRequests, prFilters, prSort, userLogin]);
+  const archivedRepoNames = useMemo(
+    () => (hideArchivedNoise ? new Set(repos.filter((repo) => repo.isArchived).map((repo) => repo.nameWithOwner)) : new Set<string>()),
+    [repos, hideArchivedNoise],
+  );
+  const filteredIssues = useMemo(() => sortIssues(filterIssues(issues, issueFilters, userLogin, archivedRepoNames), issueSort), [issues, issueFilters, issueSort, userLogin, archivedRepoNames]);
+  const filteredPullRequests = useMemo(() => sortPullRequests(filterPullRequests(pullRequests, prFilters, userLogin, archivedRepoNames), prSort), [pullRequests, prFilters, prSort, userLogin, archivedRepoNames]);
   const filteredRepos = useMemo(() => sortRepos(filterRepos(repos, issues, repoFilters), issues, repoSort, insightsByRepo), [repos, issues, repoFilters, repoSort, insightsByRepo]);
   const filteredInsights = useMemo(
     () => filteredRepos
@@ -714,8 +723,10 @@ export function App() {
         loading={loading}
         theme={theme}
         textSize={textSize}
+        hideArchivedNoise={hideArchivedNoise}
         onThemeChange={setTheme}
         onTextSizeChange={setTextSize}
+        onHideArchivedNoiseChange={setHideArchivedNoise}
         authLogin={authLogin}
         owners={owners}
         onRefresh={() => loadData(true)}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -13,10 +13,12 @@ interface TopBarProps {
   loading: boolean;
   theme: Theme;
   textSize: TextSize;
+  hideArchivedNoise: boolean;
   authLogin: string | null;
   owners: string[];
   onThemeChange: (theme: Theme) => void;
   onTextSizeChange: (textSize: TextSize) => void;
+  onHideArchivedNoiseChange: (hideArchivedNoise: boolean) => void;
   onRefresh: () => void;
   onOpenFilters: () => void;
   onOpenPalette: () => void;
@@ -30,10 +32,12 @@ export function TopBar({
   loading,
   theme,
   textSize,
+  hideArchivedNoise,
   authLogin,
   owners,
   onThemeChange,
   onTextSizeChange,
+  onHideArchivedNoiseChange,
   onRefresh,
   onOpenFilters,
   onOpenPalette,
@@ -135,6 +139,18 @@ export function TopBar({
                       {entry === "small" ? t("textSize.small") : entry === "normal" ? t("textSize.normal") : t("textSize.large")}
                     </button>
                   ))}
+                </div>
+              </div>
+              <div className="preferences-field">
+                <div className="toggle-row">
+                  <span>{t("preferences.hideArchivedNoise")}</span>
+                  <button
+                    className={`toggle ${hideArchivedNoise ? "on" : ""}`}
+                    role="switch"
+                    aria-checked={hideArchivedNoise}
+                    type="button"
+                    onClick={() => onHideArchivedNoiseChange(!hideArchivedNoise)}
+                  />
                 </div>
               </div>
             </div>

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -57,6 +57,7 @@ export const de: Record<keyof typeof en, string> = {
   "preferences.language": "Sprache",
   "preferences.theme": "Theme",
   "preferences.textSize": "Textgröße",
+  "preferences.hideArchivedNoise": "Rauschen von archivierten Repos ausblenden (PRs/Issues)",
   "textSize.small": "Klein",
   "textSize.normal": "Normal",
   "textSize.large": "Groß",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -55,6 +55,7 @@ export const en = {
   "preferences.language": "Language",
   "preferences.theme": "Theme",
   "preferences.textSize": "Text size",
+  "preferences.hideArchivedNoise": "Hide archived repo noise (PRs/issues)",
   "textSize.small": "Small",
   "textSize.normal": "Normal",
   "textSize.large": "Large",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -57,6 +57,7 @@ export const es: Record<keyof typeof en, string> = {
   "preferences.language": "Idioma",
   "preferences.theme": "Tema",
   "preferences.textSize": "Tamaño de texto",
+  "preferences.hideArchivedNoise": "Ocultar ruido de repos archivados (PR/issues)",
   "textSize.small": "Pequeño",
   "textSize.normal": "Normal",
   "textSize.large": "Grande",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -57,6 +57,7 @@ export const fr: Record<keyof typeof en, string> = {
   "preferences.language": "Langue",
   "preferences.theme": "Thème",
   "preferences.textSize": "Taille du texte",
+  "preferences.hideArchivedNoise": "Masquer le bruit des dépôts archivés (PR/issues)",
   "textSize.small": "Petit",
   "textSize.normal": "Normal",
   "textSize.large": "Grand",

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -57,6 +57,7 @@ export const it: Record<keyof typeof en, string> = {
   "preferences.language": "Lingua",
   "preferences.theme": "Tema",
   "preferences.textSize": "Dimensione testo",
+  "preferences.hideArchivedNoise": "Nascondi rumore repo archiviati (PR/issue)",
   "textSize.small": "Piccolo",
   "textSize.normal": "Normale",
   "textSize.large": "Grande",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -57,6 +57,7 @@ export const zh: Record<keyof typeof en, string> = {
   "preferences.language": "语言",
   "preferences.theme": "主题",
   "preferences.textSize": "文字大小",
+  "preferences.hideArchivedNoise": "隐藏已归档仓库的噪音（PR/issue）",
   "textSize.small": "小",
   "textSize.normal": "正常",
   "textSize.large": "大",

--- a/src/server/digests.ts
+++ b/src/server/digests.ts
@@ -34,9 +34,10 @@ async function saveDigests(): Promise<void> {
 }
 
 export async function recordDailyDigest(repos: GhRepo[], issues: GhIssue[]): Promise<void> {
+  const activeRepos = repos.filter((repo) => !repo.isArchived);
   const digests = await loadDigests();
   const securityEntries = await Promise.all(
-    repos.map(async (repo) => {
+    activeRepos.map(async (repo) => {
       try {
         const summary = await fetchRepoSecuritySummary(repo.nameWithOwner);
         return [repo.nameWithOwner, summary] as const;
@@ -45,7 +46,7 @@ export async function recordDailyDigest(repos: GhRepo[], issues: GhIssue[]): Pro
       }
     }),
   );
-  const today = buildDailyDigestRecord(repos, issues, Date.now(), new Map(securityEntries.map(([repo, summary]) => [repo, summary])));
+  const today = buildDailyDigestRecord(activeRepos, issues, Date.now(), new Map(securityEntries.map(([repo, summary]) => [repo, summary])));
   const existing = digests.find((entry) => entry.date === today.date);
   if (existing) {
     Object.assign(existing, today);

--- a/src/server/repoInsights.ts
+++ b/src/server/repoInsights.ts
@@ -83,7 +83,8 @@ export async function getRepoInsightsCached(forceFresh: boolean) {
     if (!repos.ok) return repos;
     if (!issues.ok) return issues;
 
-    const insights = await mapWithConcurrency(repos.repos, 6, async (repo) => fetchInsightForRepo(repo, issues.issues));
+    const activeRepos = repos.repos.filter((repo) => !repo.isArchived);
+    const insights = await mapWithConcurrency(activeRepos, 6, async (repo) => fetchInsightForRepo(repo, issues.issues));
     const result = {
       ok: true as const,
       generatedAt: new Date().toISOString(),

--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -131,7 +131,7 @@ export function matchesIssuePreset(issue: GhIssue, preset: string, userLogin: st
   return true;
 }
 
-export function filterIssues(issues: GhIssue[], filters: IssueFilters, userLogin: string): GhIssue[] {
+export function filterIssues(issues: GhIssue[], filters: IssueFilters, userLogin: string, archivedRepoNames: Set<string> = new Set()): GhIssue[] {
   const query = filters.search.trim().toLowerCase();
   const createdFrom = filters.dates.cf ? new Date(`${filters.dates.cf}T00:00:00`).getTime() : null;
   const createdTo = filters.dates.ct ? new Date(`${filters.dates.ct}T23:59:59`).getTime() : null;
@@ -139,6 +139,7 @@ export function filterIssues(issues: GhIssue[], filters: IssueFilters, userLogin
   const updatedTo = filters.dates.ut ? new Date(`${filters.dates.ut}T23:59:59`).getTime() : null;
 
   return issues.filter((issue) => {
+    if (archivedRepoNames.has(issue.repository.nameWithOwner)) return false;
     const owner = getOwner(issue.repository.nameWithOwner);
     if (filters.orgs.size && !filters.orgs.has(owner)) return false;
     if (filters.repos.size && !filters.repos.has(issue.repository.nameWithOwner)) return false;
@@ -199,7 +200,7 @@ export function matchesPullRequestPreset(pr: GhPullRequest, preset: string, user
   return true;
 }
 
-export function filterPullRequests(prs: GhPullRequest[], filters: PullRequestFilters, userLogin: string): GhPullRequest[] {
+export function filterPullRequests(prs: GhPullRequest[], filters: PullRequestFilters, userLogin: string, archivedRepoNames: Set<string> = new Set()): GhPullRequest[] {
   const query = filters.search.trim().toLowerCase();
   const createdFrom = filters.dates.cf ? new Date(`${filters.dates.cf}T00:00:00`).getTime() : null;
   const createdTo = filters.dates.ct ? new Date(`${filters.dates.ct}T23:59:59`).getTime() : null;
@@ -207,6 +208,7 @@ export function filterPullRequests(prs: GhPullRequest[], filters: PullRequestFil
   const updatedTo = filters.dates.ut ? new Date(`${filters.dates.ut}T23:59:59`).getTime() : null;
 
   return prs.filter((pr) => {
+    if (archivedRepoNames.has(pr.repository.nameWithOwner)) return false;
     const owner = getOwner(pr.repository.nameWithOwner);
     if (filters.orgs.size && !filters.orgs.has(owner)) return false;
     if (filters.repos.size && !filters.repos.has(pr.repository.nameWithOwner)) return false;


### PR DESCRIPTION
## Summary

Archived repos still surface open PRs/issues in the lists, and get pulled into Insights and the daily digest, even though there's nothing actionable there anymore. This adds a way to silence that noise.

- New toggle in the Preferences menu (top bar): **Hide archived repo noise (PRs/issues)**, on by default, persisted in `localStorage`.
- `filterIssues` / `filterPullRequests` (`src/utils/dashboard.ts`) accept an `archivedRepoNames` set and exclude matching entries when the preference is enabled.
- `repoInsights.ts` and `digests.ts` now always skip archived repos before fetching traffic/releases/security data, avoiding wasted GitHub API calls regardless of the client-side preference.
- The existing `includeArchived` filter on the Repos view is untouched — that one is for users who explicitly want to browse archived repos as repos, a different use case from hiding stale PR/issue/alert noise.

## Test plan

- [x] `npm run build` (typecheck + esbuild + vite) — no new errors vs. main
- [x] Manually verified on my own instance: toggling the new preference hides/shows PRs and issues from archived repos as expected