### PR TITLE
feat(repo-modal): improve details and customizable toolbar

### DIFF
--- a/src/components/common/Icons.tsx
+++ b/src/components/common/Icons.tsx
@@ -58,6 +58,10 @@ export function MailOpenIcon() {
   return <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-9" /><path d="M22 10l-10 6L2 10" /><path d="M22 10L12 3 2 10" /></svg>;
 }
 
+export function PinIcon({ filled = false }: { filled?: boolean }) {
+  return <svg width={13} height={13} viewBox="0 0 24 24" fill={filled ? "currentColor" : "none"} stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M12 17v5" /><path d="M5 17h14" /><path d="m7 3 1.5 7L6 13v2h12v-2l-2.5-3L17 3z" /></svg>;
+}
+
 export function RefreshIcon() {
   return <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><polyline points="23 4 23 10 17 10" /><polyline points="1 20 1 14 7 14" /><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" /></svg>;
 }

--- a/src/components/modals/RepositoryDetailsModal.tsx
+++ b/src/components/modals/RepositoryDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   addRepoAlias,
   fetchDependents,
@@ -16,10 +16,12 @@ import { issueCountForRepo } from "../../utils/dashboard";
 import { getLanguageColor } from "../../utils/colors";
 import { buildDailyRepoDigestMarkdown } from "../../utils/digests";
 import { isValidRepoName } from "../../utils/aliasQuery";
-import { formatBytes, formatNumber, formatRelativeTime } from "../../utils/format";
+import { formatBytes, formatNumber, formatReadableDate, formatRelativeTime } from "../../utils/format";
+import { MAX_PINNED_REPOSITORY_TABS, normalizePinnedRepositoryTabs } from "../../utils/repository";
+import type { RepositoryDetailTab } from "../../utils/repository";
 import { clampPage } from "../../utils/pagination";
 import { Pagination } from "../common/Pagination";
-import { CloseIcon, ForkIcon, IssueIcon, RefreshIcon, StarIcon } from "../common/Icons";
+import { CloseIcon, ForkIcon, IssueIcon, PinIcon, RefreshIcon, StarIcon } from "../common/Icons";
 
 interface RepositoryDetailsModalProps {
   repo: GhRepo;
@@ -31,16 +33,26 @@ interface RepositoryDetailsModalProps {
   onIssuesClick: (repo: string) => void;
 }
 
-export type DetailTab = "overview" | "actions" | "commits" | "pull-requests" | "issues" | "milestones" | "releases" | "branches" | "forks" | "traffic" | "mentions" | "discussions" | "dependents";
+export type DetailTab = RepositoryDetailTab;
 
 type ReleaseFilter = "all" | "stable" | "prerelease" | "draft";
 
 const MODAL_PAGE_SIZE = 10;
+const PINNED_TABS_STORAGE_KEY = "gitdeck.repositoryDetail.pinnedTabs";
 
 function historyDelta(repo: GhRepo, field: "stars" | "forks") {
   const history = repo.history || [];
   if (history.length < 2) return null;
   return history[history.length - 1][field] - history[0][field];
+}
+
+function loadPinnedDetailTabs(): DetailTab[] {
+  if (typeof window === "undefined") return normalizePinnedRepositoryTabs(null);
+  try {
+    return normalizePinnedRepositoryTabs(JSON.parse(window.localStorage.getItem(PINNED_TABS_STORAGE_KEY) ?? "null"));
+  } catch {
+    return normalizePinnedRepositoryTabs(null);
+  }
 }
 
 function formatReleaseDate(iso: string | null | undefined) {
@@ -152,6 +164,37 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
   const [aliasError, setAliasError] = useState("");
   const [aliasBusy, setAliasBusy] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [cloneCopied, setCloneCopied] = useState(false);
+  const [digestCopied, setDigestCopied] = useState(false);
+  const [pinnedDetailTabs, setPinnedDetailTabs] = useState<DetailTab[]>(loadPinnedDetailTabs);
+  const moreTabsRef = useRef<HTMLDetailsElement>(null);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(PINNED_TABS_STORAGE_KEY, JSON.stringify(pinnedDetailTabs));
+    } catch {
+      // Preferences remain available for the current session when storage is blocked.
+    }
+  }, [pinnedDetailTabs]);
+
+  useEffect(() => {
+    function closeMoreTabs(event: PointerEvent | KeyboardEvent) {
+      const menu = moreTabsRef.current;
+      if (!menu?.open) return;
+      if (event.type === "keydown" && (event as KeyboardEvent).key === "Escape") {
+        menu.removeAttribute("open");
+        return;
+      }
+      if (event.type === "pointerdown" && !menu.contains(event.target as Node)) menu.removeAttribute("open");
+    }
+
+    document.addEventListener("pointerdown", closeMoreTabs);
+    document.addEventListener("keydown", closeMoreTabs);
+    return () => {
+      document.removeEventListener("pointerdown", closeMoreTabs);
+      document.removeEventListener("keydown", closeMoreTabs);
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -286,9 +329,26 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
     );
   }
 
+  function togglePinnedDetailTab(tab: DetailTab) {
+    setPinnedDetailTabs((current) => {
+      if (current.includes(tab)) return current.filter((item) => item !== tab);
+      if (current.length >= MAX_PINNED_REPOSITORY_TABS) return current;
+      return [...current, tab];
+    });
+  }
+
   async function copyRepoDigest() {
     if (!details?.digest) return;
     await navigator.clipboard.writeText(buildDailyRepoDigestMarkdown(details.digest));
+    setDigestCopied(true);
+    window.setTimeout(() => setDigestCopied(false), 1600);
+  }
+
+  async function copyCloneUrl() {
+    const cloneUrl = details?.meta?.clone_url || `${repo.url.replace(/\/$/, "")}.git`;
+    await navigator.clipboard.writeText(cloneUrl);
+    setCloneCopied(true);
+    window.setTimeout(() => setCloneCopied(false), 1600);
   }
 
   async function submitAlias() {
@@ -343,6 +403,12 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
   const releases = details?.releases ?? [];
   const workflows = details?.workflows ?? [];
   const security = details?.security ?? null;
+  const latestRelease = releases.find((release) => !release.draft && !release.prerelease) ?? releases.find((release) => !release.draft) ?? null;
+  const latestWorkflow = workflows[0] ?? null;
+  const ciStatus = latestWorkflow?.conclusion ?? latestWorkflow?.status ?? null;
+  const isTemplate = repo.isTemplate || details?.meta?.is_template;
+  const isReadOnly = ["READ", "TRIAGE"].includes(repo.viewerPermission ?? "") || details?.meta?.permissions?.push === false;
+  const homepage = details?.meta?.homepage?.trim() || null;
   const totalReleaseDownloads = releases.reduce((sum, release) => sum + release.totalDownloads, 0);
   const stableReleases = releases.filter((release) => !release.prerelease && !release.draft);
   const preReleases = releases.filter((release) => release.prerelease && !release.draft);
@@ -417,6 +483,29 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
     { key: "discussions" as const, label: "Discussions", count: discussionsTotal || detailCounts?.discussions || 0 },
     { key: "dependents" as const, label: "Dependents", count: dependents.length },
   ];
+  const primaryDetailTabs = pinnedDetailTabs
+    .map((key) => detailTabs.find((item) => item.key === key))
+    .filter((item): item is (typeof detailTabs)[number] => Boolean(item));
+  const moreDetailTabs = detailTabs.filter((item) => !pinnedDetailTabs.includes(item.key));
+  const activeMoreTab = moreDetailTabs.find((item) => item.key === activeTab);
+
+  function renderDetailTab(item: (typeof detailTabs)[number], onSelect?: () => void) {
+    return (
+      <button
+        type="button"
+        key={item.key}
+        className={`repo-detail-tab ${activeTab === item.key ? "active" : ""}`}
+        aria-current={activeTab === item.key ? "page" : undefined}
+        onClick={() => {
+          onTabChange(item.key);
+          onSelect?.();
+        }}
+      >
+        <span>{item.label}</span>
+        <strong>{loading && item.key !== "overview" && item.count === 0 ? "..." : formatNumber(item.count)}</strong>
+      </button>
+    );
+  }
 
   return (
     <div className="modal-root">
@@ -431,6 +520,9 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
             </div>
           </div>
           <div className="modal-head-actions">
+            <a className="repo-open-external" href={repo.url} target="_blank" rel="noreferrer">
+              {repo.url.includes("github.com") ? "Open on GitHub" : "Open repository"} ↗
+            </a>
             <button
               className={`modal-close modal-refresh ${loading ? "refreshing" : ""}`}
               aria-label="Reload repository data"
@@ -449,12 +541,18 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
               <a className="repo-detail-title" href={repo.url} target="_blank" rel="noreferrer">{repo.nameWithOwner}</a>
               <div className="repo-badges">
                 {repo.isPrivate ? <span className="rb private">Private</span> : <span className="rb">Public</span>}
-                {repo.isArchived ? <span className="rb archived">Archived</span> : null}
+                {repo.isArchived || details?.meta?.archived ? <span className="rb archived">Archived</span> : null}
                 {repo.isFork ? <span className="rb fork">Fork</span> : null}
+                {isTemplate ? <span className="rb template">Template</span> : null}
+                {isReadOnly ? <span className="rb readonly">Read-only</span> : null}
               </div>
             </div>
             <p>{description}</p>
             {topics.length ? <div className="repo-detail-topics">{topics.slice(0, 8).map((topic) => <span key={topic}>{topic}</span>)}</div> : null}
+            <div className="repo-quick-actions" aria-label="Repository links">
+              {homepage ? <a href={homepage} target="_blank" rel="noreferrer">Documentation ↗</a> : null}
+              <button type="button" onClick={() => void copyCloneUrl()}>{cloneCopied ? "Clone URL copied" : "Copy clone URL"}</button>
+            </div>
           </section>
 
           <section className="repo-detail-stats" aria-label="Repository stats">
@@ -473,37 +571,65 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
             <div><div className="repo-detail-label">Last update</div><div className="repo-detail-value" title={new Date(repo.updatedAt).toLocaleString()}>{formatRelativeTime(repo.updatedAt)}</div></div>
             {details?.meta?.license?.name ? <div><div className="repo-detail-label">License</div><div className="repo-detail-value">{details.meta.license.name}</div></div> : null}
             {details?.meta?.default_branch ? <div><div className="repo-detail-label">Default branch</div><div className="repo-detail-value">{details.meta.default_branch}</div></div> : null}
+            {latestRelease ? <div><div className="repo-detail-label">Latest release</div><a className="repo-detail-value repo-detail-meta-link" href={latestRelease.html_url} target="_blank" rel="noreferrer" title={latestRelease.name || latestRelease.tag_name}>{latestRelease.tag_name}</a></div> : null}
+            {latestWorkflow && ciStatus ? <div><div className="repo-detail-label">CI status</div><a className={`repo-detail-value repo-detail-meta-link ci-meta-${ciStatus}`} href={latestWorkflow.html_url} target="_blank" rel="noreferrer" title={`${latestWorkflow.name || "Workflow"}: ${ciStatus}`}>{ciStatus.replaceAll("_", " ")}</a></div> : null}
           </section>
 
           <nav className="repo-detail-tabs" aria-label="Repository detail sections">
-            {detailTabs.map((item) => (
-              <button
-                type="button"
-                key={item.key}
-                className={`repo-detail-tab ${activeTab === item.key ? "active" : ""}`}
-                aria-current={activeTab === item.key ? "page" : undefined}
-                onClick={() => onTabChange(item.key)}
-              >
-                <span>{item.label}</span>
-                <strong>{loading && item.key !== "overview" && item.count === 0 ? "..." : formatNumber(item.count)}</strong>
-              </button>
-            ))}
+            <div className="repo-detail-primary-tabs">
+              {primaryDetailTabs.map((item) => renderDetailTab(item))}
+            </div>
+            <details ref={moreTabsRef} className={`repo-detail-more ${activeMoreTab ? "active" : ""}`}>
+              <summary className="repo-detail-tab" aria-label="More repository sections">
+                <span>{activeMoreTab?.label ?? "More"}</span>
+                {activeMoreTab ? <strong>{formatNumber(activeMoreTab.count)}</strong> : <span className="repo-detail-more-chevron">⌄</span>}
+              </summary>
+              <div className="repo-detail-more-menu">
+                <div className="repo-detail-more-head">
+                  <span>Customize toolbar</span>
+                  <strong>{pinnedDetailTabs.length}/{MAX_PINNED_REPOSITORY_TABS} pinned</strong>
+                </div>
+                {detailTabs.map((item) => {
+                  const pinned = pinnedDetailTabs.includes(item.key);
+                  const pinLimitReached = !pinned && pinnedDetailTabs.length >= MAX_PINNED_REPOSITORY_TABS;
+                  return (
+                    <div className="repo-detail-more-item" key={item.key}>
+                      {renderDetailTab(item, () => moreTabsRef.current?.removeAttribute("open"))}
+                      <button
+                        type="button"
+                        className={`repo-detail-pin ${pinned ? "active" : ""}`}
+                        aria-label={`${pinned ? "Unpin" : "Pin"} ${item.label}`}
+                        aria-pressed={pinned}
+                        title={pinLimitReached ? `You can pin up to ${MAX_PINNED_REPOSITORY_TABS} sections` : `${pinned ? "Unpin from" : "Pin to"} toolbar`}
+                        disabled={pinLimitReached}
+                        onClick={() => togglePinnedDetailTab(item.key)}
+                      >
+                        <PinIcon filled={pinned} />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </details>
           </nav>
 
           {activeTab === "overview" && repoDigest ? (
             <section>
               <div className="modal-section-title section-title-with-count">
                 <span>Daily repo digest</span>
-                <strong>{repoDigest.date}</strong>
+                <strong title={repoDigest.date}>{formatReadableDate(repoDigest.date)}</strong>
               </div>
               <div className="repo-detail-digest">
                 <div className="repo-detail-digest-head">
-                  <div className="repo-detail-digest-badges">
-                    <span>★ {repoDigest.starsDelta >= 0 ? "+" : ""}{formatNumber(repoDigest.starsDelta)}</span>
-                    <span>forks {repoDigest.forksDelta >= 0 ? "+" : ""}{formatNumber(repoDigest.forksDelta)}</span>
-                    <span>issues {repoDigest.issueDelta >= 0 ? "+" : ""}{formatNumber(repoDigest.issueDelta)}</span>
+                  <div>
+                    <div className="digest-comparison-label">Changes vs previous day</div>
+                    <div className="repo-detail-digest-badges">
+                      <span>★ {repoDigest.starsDelta >= 0 ? "+" : ""}{formatNumber(repoDigest.starsDelta)}</span>
+                      <span>forks {repoDigest.forksDelta >= 0 ? "+" : ""}{formatNumber(repoDigest.forksDelta)}</span>
+                      <span>issues {repoDigest.issueDelta >= 0 ? "+" : ""}{formatNumber(repoDigest.issueDelta)}</span>
+                    </div>
                   </div>
-                  <button type="button" className="digest-copy-btn" onClick={() => void copyRepoDigest()}>Copy Markdown</button>
+                  <button type="button" className={`digest-copy-btn ${digestCopied ? "copied" : ""}`} onClick={() => void copyRepoDigest()} aria-live="polite">{digestCopied ? "Copied!" : "Copy Markdown"}</button>
                 </div>
                 {repoDigest.ai ? (
                   <div className="digest-ai-block">
@@ -517,9 +643,9 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
                   </div>
                 ) : null}
                 <div className="digest-pill-groups">
-                  <div className="digest-pill-group">
+                  <div className="digest-pill-group digest-executive-summary">
                     <h4>Executive Summary</h4>
-                    {repoDigest.executiveSummary.map((item) => <span key={item}>{item}</span>)}
+                    <p>{repoDigest.executiveSummary.join(" ")}</p>
                   </div>
                   {repoDigest.momentum.length ? (
                     <div className="digest-pill-group positive">
@@ -530,7 +656,9 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
                   {repoDigest.risks.length ? (
                     <div className="digest-pill-group risk">
                       <h4>Risks</h4>
-                      {repoDigest.risks.map((item) => <span key={item}>{item}</span>)}
+                      {repoDigest.risks.map((item) => /issues/i.test(item)
+                        ? <button type="button" key={item} onClick={() => onIssuesClick(repo.nameWithOwner)} title="Open issues in dashboard">{item} ↗</button>
+                        : <span key={item}>{item}</span>)}
                     </div>
                   ) : null}
                 </div>
@@ -552,7 +680,7 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
                   <a href={person.html_url || person.url} target="_blank" rel="noreferrer" key={`${name}-${index}`}>
                     {person.avatar_url || person.avatarUrl ? <img src={person.avatar_url || person.avatarUrl} alt="" /> : <span className="repo-detail-avatar-fallback">{name.slice(0, 1).toUpperCase()}</span>}
                     <span>{name}</span>
-                    <em>{formatNumber(person.contributions)}</em>
+                    <em title={`${person.contributions.toLocaleString()} commits contributed`} aria-label={`${person.contributions.toLocaleString()} commits contributed`}>{formatNumber(person.contributions)} commits</em>
                   </a>
                   );
                 })}

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -20,4 +20,4 @@ export const ISSUE_FIELDS =
   "repository,title,url,number,createdAt,updatedAt,author,labels,commentsCount,assignees";
 
 export const REPO_FIELDS =
-  "nameWithOwner,name,owner,description,stargazerCount,forkCount,primaryLanguage,updatedAt,pushedAt,visibility,isPrivate,isArchived,isFork,url";
+  "nameWithOwner,name,owner,description,stargazerCount,forkCount,primaryLanguage,updatedAt,pushedAt,visibility,isPrivate,isArchived,isFork,isTemplate,viewerPermission,url";

--- a/src/server/providers/forgejoData.ts
+++ b/src/server/providers/forgejoData.ts
@@ -43,6 +43,8 @@ interface ForgejoRepo {
   archived?: boolean;
   fork?: boolean;
   internal?: boolean;
+  template?: boolean;
+  permissions?: { push?: boolean };
 }
 
 interface ForgejoLabel {
@@ -193,6 +195,8 @@ function normalizeRepo(raw: ForgejoRepo): GhRepo {
     isPrivate: Boolean(raw.private),
     isArchived: Boolean(raw.archived),
     isFork: Boolean(raw.fork),
+    isTemplate: Boolean(raw.template),
+    viewerPermission: raw.permissions?.push === false ? "READ" : null,
     url: raw.html_url,
   };
 }

--- a/src/server/providers/github.ts
+++ b/src/server/providers/github.ts
@@ -318,6 +318,8 @@ export class GitHubProvider implements Provider {
           isPrivate: node.isPrivate,
           isArchived: node.isArchived,
           isFork: node.isFork,
+          isTemplate: node.isTemplate,
+          viewerPermission: node.viewerPermission,
           url: node.url,
         });
       }
@@ -507,7 +509,7 @@ query($owner: String!, $cursor: String) {
         primaryLanguage { name }
         updatedAt pushedAt
         visibility
-        isPrivate isArchived isFork url
+        isPrivate isArchived isFork isTemplate viewerPermission url
       }
     }
   }
@@ -619,6 +621,8 @@ interface RepoNode {
   isPrivate: boolean;
   isArchived: boolean;
   isFork: boolean;
+  isTemplate: boolean;
+  viewerPermission: string | null;
   url: string;
 }
 

--- a/src/styles/modals.css
+++ b/src/styles/modals.css
@@ -50,6 +50,13 @@
   }
   .modal-close:hover { color: var(--text); background: var(--panel-3); }
   .modal-head-actions { display: inline-flex; align-items: center; gap: 2px; }
+  .repo-open-external {
+    display: inline-flex; align-items: center; min-height: 30px; margin-right: 4px;
+    padding: 0 10px; border-radius: 6px; border: 1px solid var(--border-soft);
+    background: var(--panel-3); color: var(--text); font-size: 12px; font-weight: 700;
+    white-space: nowrap;
+  }
+  .repo-open-external:hover { color: var(--accent-2); border-color: var(--button-hover-border); text-decoration: none; }
   .modal-refresh:disabled { cursor: default; }
   .modal-refresh.refreshing svg { animation: modalRefreshSpin 1s linear infinite; }
   @keyframes modalRefreshSpin { to { transform: rotate(360deg); } }
@@ -260,6 +267,14 @@
     border-radius: 6px;
   }
   .repo-detail-topics span:hover { color: var(--text); border-color: var(--button-hover-border); }
+  .repo-quick-actions { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; margin-top: 12px; }
+  .repo-quick-actions a,
+  .repo-quick-actions button {
+    padding: 5px 9px; border-radius: 6px; border: 1px solid var(--border-soft);
+    background: var(--panel-2); color: var(--muted); font: inherit; font-size: 11.5px; cursor: pointer;
+  }
+  .repo-quick-actions a:hover,
+  .repo-quick-actions button:hover { color: var(--text); background: var(--panel-3); text-decoration: none; }
   .repo-detail-stats {
     display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 10px; padding: 12px 18px;
@@ -280,12 +295,19 @@
   }
   .repo-detail-label { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); font-weight: 700; margin-bottom: 4px; }
   .repo-detail-value { display: flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .repo-detail-meta-link { width: fit-content; max-width: 100%; text-transform: none; }
+  .repo-detail-meta-link:hover { color: var(--accent-2); text-decoration: none; }
+  .repo-detail-meta-link[class*="ci-meta-success"] { color: #86efac; }
+  .repo-detail-meta-link[class*="ci-meta-failure"],
+  .repo-detail-meta-link[class*="ci-meta-timed_out"] { color: #fca5a5; }
+  .repo-detail-meta-link[class*="ci-meta-in_progress"],
+  .repo-detail-meta-link[class*="ci-meta-queued"] { color: #67e8f9; }
   .repo-detail-tabs {
     position: sticky;
     top: 0;
     z-index: 3;
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
     gap: 4px;
     padding: 8px 12px;
     background: color-mix(in srgb, var(--panel) 94%, transparent);
@@ -310,6 +332,39 @@
     white-space: nowrap;
   }
   .repo-detail-tab:hover { color: var(--text); background: var(--hover-surface); }
+  .repo-detail-primary-tabs { display: flex; align-items: center; gap: 4px; min-width: 0; overflow-x: auto; scrollbar-width: none; }
+  .repo-detail-primary-tabs::-webkit-scrollbar { display: none; }
+  .repo-detail-more { position: relative; margin-left: auto; flex: 0 0 auto; }
+  .repo-detail-more > summary { list-style: none; }
+  .repo-detail-more > summary::-webkit-details-marker { display: none; }
+  .repo-detail-more-chevron { color: var(--muted); font-size: 14px; line-height: 1; }
+  .repo-detail-more[open] > summary,
+  .repo-detail-more.active > summary { color: var(--text); background: var(--panel-3); border-color: var(--border-soft); }
+  .repo-detail-more[open] .repo-detail-more-chevron { transform: rotate(180deg); }
+  .repo-detail-more-menu {
+    position: absolute; top: calc(100% + 7px); right: 0; z-index: 10;
+    display: grid; grid-template-columns: repeat(2, minmax(175px, 1fr)); gap: 4px;
+    width: min(420px, calc(100vw - 32px)); padding: 7px;
+    border: 1px solid var(--border-soft); border-radius: 9px;
+    background: var(--panel-2); box-shadow: 0 14px 32px rgba(0,0,0,0.42);
+  }
+  .repo-detail-more-head {
+    grid-column: 1 / -1; display: flex; align-items: center; justify-content: space-between; gap: 12px;
+    padding: 5px 7px 8px; margin-bottom: 2px; border-bottom: 1px solid var(--border-soft);
+    color: var(--muted); font-size: 10.5px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+  }
+  .repo-detail-more-head strong { color: var(--muted); font-size: 10px; white-space: nowrap; }
+  .repo-detail-more-item { display: flex; align-items: center; min-width: 0; border-radius: 7px; }
+  .repo-detail-more-item:hover { background: var(--hover-surface); }
+  .repo-detail-more-menu .repo-detail-tab { flex: 1; min-width: 0; justify-content: space-between; }
+  .repo-detail-pin {
+    display: inline-grid; place-items: center; flex: 0 0 auto; width: 30px; height: 30px;
+    padding: 0; border: 0; border-radius: 6px; background: transparent; color: var(--muted);
+    cursor: pointer;
+  }
+  .repo-detail-pin:hover { color: var(--text); background: var(--panel-3); }
+  .repo-detail-pin.active { color: var(--accent-2); }
+  .repo-detail-pin:disabled { opacity: 0.3; cursor: not-allowed; }
   .repo-detail-tab.active {
     color: var(--text);
     background: var(--panel-3);
@@ -490,7 +545,10 @@
   .repo-detail-digest-head {
     display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;
   }
+  .digest-comparison-label { margin-bottom: 6px; color: var(--muted); font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; }
   .repo-detail-digest-badges { display: flex; gap: 8px; flex-wrap: wrap; }
+  .digest-executive-summary { display: block; }
+  .digest-executive-summary p { margin: 0; color: var(--text); font-size: 12.5px; line-height: 1.55; }
   .repo-detail-digest-badges span {
     background: var(--panel-2); border: 1px solid var(--border-soft);
     border-radius: 999px; padding: 4px 9px; font-size: 11.5px; color: var(--text);
@@ -657,6 +715,7 @@
   .repo-detail-issue strong { font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .repo-detail-issue em { color: var(--muted); font-style: normal; font-size: 12px; white-space: nowrap; }
   @media (max-width: 720px) {
+    .repo-open-external { max-width: 142px; overflow: hidden; text-overflow: ellipsis; }
     .repo-detail-stats, .repo-detail-grid { grid-template-columns: 1fr; }
     .repo-detail-traffic-grid { grid-template-columns: 1fr; }
     .repo-chart-grid { grid-template-columns: 1fr; }
@@ -673,6 +732,7 @@
       padding: 7px 10px;
       gap: 3px;
     }
+    .repo-detail-more-menu { grid-template-columns: 1fr; width: min(250px, calc(100vw - 24px)); max-height: 60vh; overflow-y: auto; }
     .repo-detail-tab {
       min-height: 32px;
       padding: 0 9px;

--- a/src/styles/views.css
+++ b/src/styles/views.css
@@ -442,6 +442,8 @@
   .rb.private { color: #ffd79a; background: rgba(245,158,11,0.08); border-color: rgba(245,158,11,0.25); }
   .rb.archived { color: #fca5a5; background: rgba(239,68,68,0.08); border-color: rgba(239,68,68,0.25); }
   .rb.fork { color: #a5b4fc; background: rgba(129,140,248,0.08); border-color: rgba(129,140,248,0.25); }
+  .rb.template { color: #67e8f9; background: rgba(34,211,238,0.08); border-color: rgba(34,211,238,0.25); }
+  .rb.readonly { color: #cbd5e1; background: rgba(148,163,184,0.08); border-color: rgba(148,163,184,0.25); }
   .rb.prerelease { color: #fdba74; background: rgba(249,115,22,0.08); border-color: rgba(249,115,22,0.25); }
   .rb.draft { color: #9ca3af; background: rgba(156,163,175,0.08); border-color: rgba(156,163,175,0.3); }
   .rb.answered { color: #86efac; background: rgba(34,197,94,0.08); border-color: rgba(34,197,94,0.25); }
@@ -648,6 +650,7 @@
     border-radius: 999px; padding: 4px 10px; font-size: 11.5px; cursor: pointer;
   }
   .digest-copy-btn:hover { background: var(--panel-3); }
+  .digest-copy-btn.copied { color: #86efac; border-color: rgba(34,197,94,0.35); background: rgba(34,197,94,0.1); }
   .digest-ai-block {
     display: flex; flex-direction: column; gap: 8px;
     padding: 12px 14px;
@@ -680,9 +683,13 @@
   .digest-pill-group.positive span {
     background: rgba(34,197,94,0.1); border-color: rgba(34,197,94,0.25); color: #d1fae5;
   }
-  .digest-pill-group.risk span {
-    background: rgba(239,68,68,0.1); border-color: rgba(239,68,68,0.25); color: #fecaca;
+  .digest-pill-group.risk span,
+  .digest-pill-group.risk button {
+    background: rgba(239,68,68,0.1); border: 1px solid rgba(239,68,68,0.25); color: #fecaca;
+    border-radius: 999px; padding: 5px 9px; font-size: 11.5px;
   }
+  .digest-pill-group.risk button { cursor: pointer; font-family: inherit; }
+  .digest-pill-group.risk button:hover { background: rgba(239,68,68,0.18); }
   .digest-summary p {
     margin: 0; font-size: 12.5px; color: var(--text); line-height: 1.45;
   }

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -102,6 +102,8 @@ export interface GhRepo {
   isPrivate: boolean;
   isArchived: boolean;
   isFork: boolean;
+  isTemplate?: boolean;
+  viewerPermission?: string | null;
   url: string;
   history?: SnapshotEntry[];
 }
@@ -289,9 +291,13 @@ export interface RepoDetailsData {
   meta: {
     description?: string | null;
     homepage?: string | null;
+    clone_url?: string | null;
     topics?: string[];
     license?: { name: string } | null;
     default_branch?: string;
+    archived?: boolean;
+    is_template?: boolean;
+    permissions?: { push?: boolean };
   } | null;
   languages: Record<string, number>;
   contributors: RepoContributor[];

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -86,6 +86,18 @@ export function formatExactNumber(value: number): string {
   return new Intl.NumberFormat("en-US").format(value);
 }
 
+export function formatReadableDate(iso: string, locale = "en-US"): string {
+  if (!iso) return "";
+  const date = /^\d{4}-\d{2}-\d{2}$/.test(iso) ? new Date(`${iso}T12:00:00Z`) : new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
+
 export function formatBytes(value: number): string {
   if (!value) return "0 B";
   const units = ["B", "KB", "MB", "GB"];

--- a/src/utils/repository.ts
+++ b/src/utils/repository.ts
@@ -1,6 +1,34 @@
 const REPOSITORY_PATTERN = /^([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)$/;
 const REPO_API_PREFIX = "https://api.github.com/repos/";
 
+export const REPOSITORY_DETAIL_TAB_KEYS = [
+  "overview",
+  "actions",
+  "commits",
+  "pull-requests",
+  "issues",
+  "milestones",
+  "releases",
+  "branches",
+  "forks",
+  "traffic",
+  "mentions",
+  "discussions",
+  "dependents",
+] as const;
+
+export type RepositoryDetailTab = (typeof REPOSITORY_DETAIL_TAB_KEYS)[number];
+
+export const DEFAULT_PINNED_REPOSITORY_TABS: RepositoryDetailTab[] = ["overview", "pull-requests", "issues"];
+export const MAX_PINNED_REPOSITORY_TABS = 5;
+
+export function normalizePinnedRepositoryTabs(value: unknown): RepositoryDetailTab[] {
+  if (!Array.isArray(value)) return [...DEFAULT_PINNED_REPOSITORY_TABS];
+  const available = new Set<string>(REPOSITORY_DETAIL_TAB_KEYS);
+  return [...new Set(value.filter((item): item is RepositoryDetailTab => typeof item === "string" && available.has(item)))]
+    .slice(0, MAX_PINNED_REPOSITORY_TABS);
+}
+
 export function parseRepositoryName(raw: string | null): [string, string] | null {
   if (!raw) return null;
   const match = REPOSITORY_PATTERN.exec(raw);

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatBytes, formatExactNumber, formatNumber, formatRelativeTime } from "../../src/utils/format";
+import { formatBytes, formatExactNumber, formatNumber, formatReadableDate, formatRelativeTime } from "../../src/utils/format";
 
 describe("format utilities", () => {
   it("formats relative time using the provided clock", () => {
@@ -38,6 +38,11 @@ describe("format utilities", () => {
   it("formats exact numbers", () => {
     expect(formatExactNumber(1_329)).toBe("1,329");
     expect(formatExactNumber(2_000_000)).toBe("2,000,000");
+  });
+
+  it("formats date-only values without timezone shifts", () => {
+    expect(formatReadableDate("2026-08-19")).toBe("Aug 19, 2026");
+    expect(formatReadableDate("not-a-date")).toBe("not-a-date");
   });
 
   it("formats byte values", () => {

--- a/tests/utils/repository.test.ts
+++ b/tests/utils/repository.test.ts
@@ -3,6 +3,7 @@ import {
   getOwner,
   getRepositoryName,
   nameWithOwnerFromApiUrl,
+  normalizePinnedRepositoryTabs,
   parseRepositoryName,
 } from "../../src/utils/repository";
 
@@ -29,5 +30,25 @@ describe("repository utilities", () => {
 
   it("returns the input unchanged when it is not a repository API url", () => {
     expect(nameWithOwnerFromApiUrl("openai/codex")).toBe("openai/codex");
+  });
+
+  it("normalizes pinned repository tabs", () => {
+    expect(normalizePinnedRepositoryTabs(null)).toEqual(["overview", "pull-requests", "issues"]);
+    expect(normalizePinnedRepositoryTabs(["issues", "commits", "issues", "invalid", "forks"])).toEqual([
+      "issues",
+      "commits",
+      "forks",
+    ]);
+  });
+
+  it("limits the number of pinned repository tabs", () => {
+    expect(normalizePinnedRepositoryTabs([
+      "overview",
+      "actions",
+      "commits",
+      "pull-requests",
+      "issues",
+      "milestones",
+    ])).toHaveLength(5);
   });
 });


### PR DESCRIPTION
## Summary
- enrich repository details with forge links, clone/documentation actions, release and CI metadata, and repository state badges
- improve daily digest readability, copy feedback, issue risk navigation, and contributor labels
- replace the crowded tab strip with a customizable pinned toolbar and persisted preferences
- support template/read-only repository metadata across GitHub and Forgejo providers

## Validation
- `npm test` (83 tests passed)
- `npm run build`

## Notes
- `npm run typecheck` still reports pre-existing errors in list views, digest types, and color utility tests.
