### PR TITLE
perf: load provider resources on demand

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ import {
   type RepoFilters,
 } from "./utils/dashboard";
 import { clampPage } from "./utils/pagination";
+import { allDashboardResources, dataRequirementsForTab, type DashboardResource } from "./utils/dataRequirements";
 import { getOwner } from "./utils/repository";
 import { formatNumber } from "./utils/format";
 import { clearStatsCache, readStatsCache, writeStatsCache } from "./utils/statsCache";
@@ -164,7 +165,7 @@ type AuthState = "checking" | "anonymous" | "authenticated";
 export function App() {
   const { t } = useI18n();
   const projectsEnabled = useCapability("projects");
-  const { active: activeAccount } = useAccounts();
+  const { active: activeAccount, loading: accountsLoading } = useAccounts();
   const activeAccountId = activeAccount?.id ?? null;
   const location = useLocation();
   const navigate = useNavigate();
@@ -188,6 +189,7 @@ export function App() {
   const [repos, setRepos] = useState<GhRepo[]>([]);
   const [owners, setOwners] = useState<string[]>([]);
   const [repoInsights, setRepoInsights] = useState<RepoInsight[]>([]);
+  const [visibleRepoInsightNames, setVisibleRepoInsightNames] = useState<string[]>([]);
   const [dailyDigests, setDailyDigests] = useState<DailyDigestEntry[]>([]);
   const [digestPeriod, setDigestPeriod] = useState<DigestPeriod>(() => (localStorage.getItem("gh-dash.digestPeriod") as DigestPeriod) || "day");
   const [ciHealth, setCiHealth] = useState<RepoCIHealth[]>([]);
@@ -223,28 +225,28 @@ export function App() {
   const [issuePageSize, setIssuePageSize] = useState(Number(localStorage.getItem("gh-dash.issuesPageSize")) || 20);
   const [prPageSize, setPrPageSize] = useState(Number(localStorage.getItem("gh-dash.prsPageSize")) || 20);
   const [repoPageSize, setRepoPageSize] = useState(Number(localStorage.getItem("gh-dash.reposPageSize")) || 20);
-  const abortRef = useRef<AbortController | null>(null);
-  const initialLoadRef = useRef(false);
+  const abortControllersRef = useRef(new Set<AbortController>());
+  const activeLoadsRef = useRef(0);
+  const loadedAccountRef = useRef<string | null>(null);
 
-  const loadData = useCallback((fresh = false) => {
-    abortRef.current?.abort();
+  const loadData = useCallback((resources: Set<DashboardResource>, fresh = false) => {
     const controller = new AbortController();
-    abortRef.current = controller;
+    abortControllersRef.current.add(controller);
     setError("");
-    setDataStale(true);
 
-    const cachedRepos = peek<ReposData>(CACHE_KEY.repos);
+    const cachedRepos = resources.has("repos") ? peek<ReposData>(CACHE_KEY.repos) : null;
     if (cachedRepos) {
       setRepos(cachedRepos.repos);
       setOwners(cachedRepos.owners);
       setFetchedAt(cachedRepos.fetchedAt);
     }
-    const cachedIssues = peek<IssuesData>(CACHE_KEY.issues);
+    const cachedIssues = resources.has("issues") ? peek<IssuesData>(CACHE_KEY.issues) : null;
     if (cachedIssues) setIssues(cachedIssues.issues);
-    const cachedPrs = peek<PullRequestsData>(CACHE_KEY.prs);
+    const cachedPrs = resources.has("prs") ? peek<PullRequestsData>(CACHE_KEY.prs) : null;
     if (cachedPrs) setPullRequests(cachedPrs.pullRequests);
 
-    // Fall back to localStorage when in-memory cache is empty (page refresh)
+    // Local persisted data costs no provider requests and keeps previously visited
+    // tabs warm after a browser refresh.
     if (!cachedRepos && !cachedIssues && !cachedPrs) {
       const persisted = readStatsCache();
       if (persisted) {
@@ -256,11 +258,20 @@ export function App() {
       }
     }
 
-    let pending = 3;
+    let pending = resources.size;
+    if (!pending) {
+      abortControllersRef.current.delete(controller);
+      return;
+    }
+    activeLoadsRef.current += 1;
     setLoading(true);
+    setDataStale(true);
     const finish = () => {
       pending -= 1;
-      if (pending <= 0 && abortRef.current === controller) {
+      if (pending > 0 || !abortControllersRef.current.has(controller)) return;
+      abortControllersRef.current.delete(controller);
+      activeLoadsRef.current = Math.max(0, activeLoadsRef.current - 1);
+      if (activeLoadsRef.current === 0) {
         setLoading(false);
         setDataStale(false);
       }
@@ -276,37 +287,35 @@ export function App() {
       setError((err as Error).message);
     };
 
-    void swr<ReposData>(CACHE_KEY.repos, (signal) => fetchRepos(fresh, signal), {
-      fresh,
-      signal: controller.signal,
-    }).promise
-      .then((data) => {
+    if (resources.has("repos")) {
+      void swr<ReposData>(CACHE_KEY.repos, (signal) => fetchRepos(fresh, signal), {
+        fresh,
+        signal: controller.signal,
+      }).promise.then((data) => {
         if (controller.signal.aborted) return;
         setRepos(data.repos);
         setOwners(data.owners);
         setFetchedAt(data.fetchedAt);
-      }, handleFailure)
-      .finally(finish);
+      }, handleFailure).finally(finish);
+    }
 
-    void swr<IssuesData>(CACHE_KEY.issues, (signal) => fetchIssues(fresh, signal), {
-      fresh,
-      signal: controller.signal,
-    }).promise
-      .then((data) => {
-        if (controller.signal.aborted) return;
-        setIssues(data.issues);
-      }, handleFailure)
-      .finally(finish);
+    if (resources.has("issues")) {
+      void swr<IssuesData>(CACHE_KEY.issues, (signal) => fetchIssues(fresh, signal), {
+        fresh,
+        signal: controller.signal,
+      }).promise.then((data) => {
+        if (!controller.signal.aborted) setIssues(data.issues);
+      }, handleFailure).finally(finish);
+    }
 
-    void swr<PullRequestsData>(CACHE_KEY.prs, (signal) => fetchPullRequests(fresh, signal), {
-      fresh,
-      signal: controller.signal,
-    }).promise
-      .then((data) => {
-        if (controller.signal.aborted) return;
-        setPullRequests(data.pullRequests);
-      }, handleFailure)
-      .finally(finish);
+    if (resources.has("prs")) {
+      void swr<PullRequestsData>(CACHE_KEY.prs, (signal) => fetchPullRequests(fresh, signal), {
+        fresh,
+        signal: controller.signal,
+      }).promise.then((data) => {
+        if (!controller.signal.aborted) setPullRequests(data.pullRequests);
+      }, handleFailure).finally(finish);
+    }
   }, []);
 
   useEffect(() => {
@@ -325,28 +334,43 @@ export function App() {
 
   useEffect(() => {
     if (authState !== "authenticated") {
-      initialLoadRef.current = false;
+      loadedAccountRef.current = null;
       return;
     }
-    if (!initialLoadRef.current) {
-      initialLoadRef.current = true;
-      loadData();
-      return;
-    }
-    setIssues([]);
-    setPullRequests([]);
-    setRepos([]);
-    setOwners([]);
-    setRepoInsights([]);
-    setDailyDigests([]);
-    setCiHealth([]);
-    setNotifications([]);
-    setFetchedAt("");
-    clearStatsCache();
-    loadData(true);
-  }, [authState, activeAccountId, loadData]);
+    if (accountsLoading) return;
 
-  useEffect(() => () => abortRef.current?.abort(), []);
+    const accountKey = activeAccountId ?? authLogin ?? "authenticated";
+    const accountChanged = loadedAccountRef.current !== null && loadedAccountRef.current !== accountKey;
+    if (accountChanged) {
+      for (const controller of abortControllersRef.current) controller.abort();
+      abortControllersRef.current.clear();
+      activeLoadsRef.current = 0;
+      setLoading(false);
+      setDataStale(false);
+      setIssues([]);
+      setPullRequests([]);
+      setRepos([]);
+      setOwners([]);
+      setRepoInsights([]);
+      setDailyDigests([]);
+      setCiHealth([]);
+      setNotifications([]);
+      setFetchedAt("");
+      clearStatsCache();
+    }
+    loadedAccountRef.current = accountKey;
+    loadData(dataRequirementsForTab(tab, Boolean(routeRepoName), repoDetailTab), accountChanged);
+  }, [authState, accountsLoading, activeAccountId, authLogin, tab, routeRepoName, repoDetailTab, loadData]);
+
+  useEffect(() => {
+    if (authState !== "authenticated" || !paletteOpen) return;
+    loadData(allDashboardResources());
+  }, [authState, paletteOpen, loadData]);
+
+  useEffect(() => () => {
+    for (const controller of abortControllersRef.current) controller.abort();
+    abortControllersRef.current.clear();
+  }, []);
 
   // Persist dashboard data to localStorage for instant display on next page load
   useEffect(() => {
@@ -359,24 +383,6 @@ export function App() {
       fetchedAt,
     });
   }, [repos, owners, issues, pullRequests, fetchedAt]);
-
-  useEffect(() => {
-    if (authState !== "authenticated") return;
-    if (tab !== "insights" && tab !== "alerts" && tab !== "repos") return;
-    const cached = peek<RepoInsightsData>(CACHE_KEY.insights);
-    if (cached) setRepoInsights(cached.insights);
-    const controller = new AbortController();
-    swr<RepoInsightsData>(
-      CACHE_KEY.insights,
-      (signal) => fetchRepoInsights(false, signal),
-      { signal: controller.signal },
-    ).promise
-      .then((data) => {
-        if (!controller.signal.aborted) setRepoInsights(data.insights);
-      })
-      .catch(() => {});
-    return () => controller.abort();
-  }, [tab, authState, activeAccountId]);
 
   useEffect(() => {
     if (authState !== "authenticated") return;
@@ -416,7 +422,9 @@ export function App() {
   }, [digestPeriod]);
 
   async function handleLogout() {
-    abortRef.current?.abort();
+    for (const controller of abortControllersRef.current) controller.abort();
+    abortControllersRef.current.clear();
+    activeLoadsRef.current = 0;
     try {
       await logoutAuth();
     } catch {
@@ -504,15 +512,15 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    if (authState !== "authenticated") return;
-    void refreshNotifications(true);
-  }, [authState, activeAccountId, refreshNotifications]);
+    if (authState !== "authenticated" || tab !== "inbox") return;
+    void refreshNotifications();
+  }, [authState, activeAccountId, tab, refreshNotifications]);
 
   useEffect(() => {
-    if (authState !== "authenticated" || !pollInterval) return;
+    if (authState !== "authenticated" || tab !== "inbox" || !pollInterval) return;
     const id = window.setInterval(() => { void refreshNotifications(); }, Math.max(30, pollInterval) * 1000);
     return () => window.clearInterval(id);
-  }, [authState, pollInterval, refreshNotifications]);
+  }, [authState, tab, pollInterval, refreshNotifications]);
 
   const handleMarkRead = useCallback(async (threadId: string) => {
     setNotifications((prev) => prev.map((entry) => (entry.id === threadId ? { ...entry, unread: false } : entry)));
@@ -621,6 +629,53 @@ export function App() {
   const visibleIssues = filteredIssues.slice((issuePageSafe - 1) * issuePageSize, issuePageSafe * issuePageSize);
   const visiblePullRequests = filteredPullRequests.slice((prPageSafe - 1) * prPageSize, prPageSafe * prPageSize);
   const visibleRepos = filteredRepos.slice((repoPageSafe - 1) * repoPageSize, repoPageSafe * repoPageSize);
+  const repoInsightTargets = tab === "repos"
+    ? (repoSort.startsWith("health_")
+      ? filteredRepos.map((repo) => repo.nameWithOwner)
+      : visibleRepoInsightNames.filter((repo) => visibleRepos.some((entry) => entry.nameWithOwner === repo)))
+      .filter((repo) => !insightsByRepo.has(repo))
+      .sort()
+    : [];
+  const repoInsightTargetKey = repoInsightTargets.join("\n");
+  const handleVisibleRepoInsightsChange = useCallback((names: string[]) => {
+    setVisibleRepoInsightNames((current) => {
+      if (current.length === names.length && current.every((name, index) => name === names[index])) return current;
+      return names;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (authState !== "authenticated") return;
+    if (tab !== "repos" && tab !== "insights" && tab !== "alerts") return;
+    const targeted = tab === "repos";
+    if (targeted && !repoInsightTargets.length) return;
+    const cacheKey = targeted
+      ? `${CACHE_KEY.insights}?${new URLSearchParams(repoInsightTargets.map((repo) => ["repo", repo])).toString()}`
+      : CACHE_KEY.insights;
+    const cached = peek<RepoInsightsData>(cacheKey);
+    if (cached) {
+      if (!targeted) setRepoInsights(cached.insights);
+      else setRepoInsights((current) => {
+        const merged = new Map(current.map((insight) => [insight.repo, insight]));
+        for (const insight of cached.insights) merged.set(insight.repo, insight);
+        return [...merged.values()];
+      });
+    }
+    const controller = new AbortController();
+    swr<RepoInsightsData>(cacheKey, (signal) => fetchRepoInsights(false, signal, repoInsightTargets), {
+      signal: controller.signal,
+    }).promise.then((data) => {
+      if (controller.signal.aborted) return;
+      if (!targeted) setRepoInsights(data.insights);
+      else setRepoInsights((current) => {
+        const merged = new Map(current.map((insight) => [insight.repo, insight]));
+        for (const insight of data.insights) merged.set(insight.repo, insight);
+        return [...merged.values()];
+      });
+    }).catch(() => {});
+    return () => controller.abort();
+  }, [tab, authState, activeAccountId, repoInsightTargetKey]);
+
   const draftCount = pullRequests.filter((pr) => pr.isDraft).length;
   const awaitingReviewCount = pullRequests.filter((pr) => !pr.isDraft && pr.reviewsCount === 0).length;
   const approvedCount = pullRequests.filter((pr) => pr.reviewDecision === "APPROVED").length;
@@ -752,7 +807,8 @@ export function App() {
         onHideArchivedNoiseChange={setHideArchivedNoise}
         authLogin={authLogin}
         owners={owners}
-        onRefresh={() => loadData(true)}
+        githubAvatars={activeAccount?.providerKind === "github"}
+        onRefresh={() => loadData(dataRequirementsForTab(tab, Boolean(routeRepoName), repoDetailTab), true)}
         onOpenFilters={() => setFiltersOpen(true)}
         onOpenPalette={() => setPaletteOpen(true)}
         onLogout={() => void handleLogout()}
@@ -777,6 +833,7 @@ export function App() {
           onClose={() => setFiltersOpen(false)}
           authLogin={authLogin || undefined}
           inbox={inboxSidebar}
+          githubAvatars={activeAccount?.providerKind === "github"}
         />
         <main className={`main${dataStale ? " data-stale" : ""}`}>
           {error ? <div className="error">{error}</div> : null}
@@ -914,6 +971,7 @@ export function App() {
                 onIssuesClick={(repo) => { setIssueFilters({ ...issueFilters, repos: new Set([repo]) }); navigateTab("issues"); }}
                 onStarsClick={(repo) => openMetricModal(repo, "stars")}
                 onForksClick={(repo) => openMetricModal(repo, "forks")}
+                onVisibleReposChange={handleVisibleRepoInsightsChange}
               />
               <Pagination totalItems={filteredRepos.length} page={repoPageSafe} pageSize={repoPageSize} onPageChange={setRepoPage} onPageSizeChange={(size) => { setRepoPageSize(size); setRepoPage(1); }} />
             </div>
@@ -998,7 +1056,7 @@ export function App() {
           pullRequests={pullRequests}
           onNavigateTab={(next) => navigateTab(next)}
           onOpenRepo={(repo) => openRepoModal(repo)}
-          onRefresh={() => loadData(true)}
+          onRefresh={() => loadData(allDashboardResources(), true)}
           onToggleTheme={cycleTheme}
           onClose={() => setPaletteOpen(false)}
         />

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -1,4 +1,4 @@
-import { getEtag, peek, setEtag } from "./cache";
+import { getEtag, peek, setEtag, swr } from "./cache";
 import type {
   ApiError,
   CIHealthData,
@@ -198,9 +198,12 @@ export function fetchForks(params: {
   return readJson(`/api/forks?${query.toString()}`);
 }
 
-export function fetchRepoDetails(repo: string): Promise<RepoDetailsData> {
-  const query = new URLSearchParams({ repo });
-  return readJson(`/api/repo-details?${query.toString()}`);
+export type RepoDetailsSection = "overview" | "actions" | "commits" | "milestones" | "releases" | "traffic" | "minimal";
+
+export function fetchRepoDetails(repo: string, section: RepoDetailsSection = "overview", fresh = false): Promise<RepoDetailsData> {
+  const query = new URLSearchParams({ repo, section });
+  const url = `/api/repo-details?${query.toString()}`;
+  return swr<RepoDetailsData>(url, () => readJson(url, undefined, url), { fresh }).promise;
 }
 
 export function fetchRepoBranches(repo: string): Promise<{ ok: true; totalCount: number; defaultBranch: string | null; branches: RepoBranch[] }> {
@@ -252,8 +255,13 @@ export function fetchRepoTraffic(repo: string): Promise<RepoTrafficDetails> {
   return readJson(`/api/mentions/referrers?${query.toString()}`);
 }
 
-export function fetchRepoInsights(fresh = false, signal?: AbortSignal): Promise<RepoInsightsData> {
-  return readJson(`/api/repo-insights${fresh ? "?fresh=1" : ""}`, withSignal(signal), "/api/repo-insights");
+export function fetchRepoInsights(fresh = false, signal?: AbortSignal, repos: string[] = []): Promise<RepoInsightsData> {
+  const query = new URLSearchParams();
+  if (fresh) query.set("fresh", "1");
+  for (const repo of repos) query.append("repo", repo);
+  const suffix = query.size ? `?${query.toString()}` : "";
+  const cacheKey = repos.length ? `/api/repo-insights?${new URLSearchParams([...repos].sort().map((repo) => ["repo", repo])).toString()}` : "/api/repo-insights";
+  return readJson(`/api/repo-insights${suffix}`, withSignal(signal), cacheKey);
 }
 
 export function fetchDailyDigests(signal?: AbortSignal, period: "day" | "week" | "month" = "day"): Promise<DailyDigestsData> {

--- a/src/components/SidebarControls.tsx
+++ b/src/components/SidebarControls.tsx
@@ -45,6 +45,7 @@ interface SidebarControlsProps {
   onClose: () => void;
   authLogin?: string;
   inbox?: InboxSidebarState;
+  githubAvatars?: boolean;
 }
 
 function toggleSetValue(values: Set<string>, value: string): Set<string> {
@@ -96,7 +97,7 @@ function CheckList({
             <input type="checkbox" checked={selected.has(name)} onChange={() => onToggle(name)} />
             {showSwatch && color ? <span className="label-swatch" style={{ background: `#${color}` }} /> : null}
             {languageDot ? <span className="label-swatch" style={{ borderRadius: "50%", background: getLanguageColor(name) }} /> : null}
-            {showGhAvatar ? <img src={`https://github.com/${name}.png?size=32`} alt="" style={{ width: 16, height: 16, borderRadius: "50%", flexShrink: 0 }} /> : null}
+            {showGhAvatar ? <img src={`https://github.com/${name}.png?size=32`} alt="" loading="lazy" referrerPolicy="no-referrer" style={{ width: 16, height: 16, borderRadius: "50%", flexShrink: 0 }} /> : null}
             <span className="label-text">{name}</span>
             <span className="label-count">{countOf(value)}</span>
           </label>
@@ -149,7 +150,7 @@ function FilterSection({ title, activeCount, children, dataFor, open = false, on
           <span className={`count ${activeCount ? "active" : ""}`}>{activeCount}</span>
         )}
       </summary>
-      <div className="section-body">{children}</div>
+      {effectiveOpen ? <div className="section-body">{children}</div> : null}
     </details>
   );
 }
@@ -171,6 +172,7 @@ export function SidebarControls({
   onClose,
   authLogin,
   inbox,
+  githubAvatars = true,
 }: SidebarControlsProps) {
   const { t } = useI18n();
   const inboxMode = tab === "inbox";
@@ -252,7 +254,7 @@ export function SidebarControls({
         <CheckList
           entries={[...orgEntries.entries()]}
           selected={orgSelection}
-          showGhAvatar
+          showGhAvatar={githubAvatars}
           userLogin={authLogin || undefined}
           onToggle={(value) => ticketMode
             ? onActiveFiltersChange({ ...activeFilters, orgs: toggleSetValue(activeFilters.orgs, value) })

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -16,6 +16,7 @@ interface TopBarProps {
   hideArchivedNoise: boolean;
   authLogin: string | null;
   owners: string[];
+  githubAvatars?: boolean;
   onThemeChange: (theme: Theme) => void;
   onTextSizeChange: (textSize: TextSize) => void;
   onHideArchivedNoiseChange: (hideArchivedNoise: boolean) => void;
@@ -35,6 +36,7 @@ export function TopBar({
   hideArchivedNoise,
   authLogin,
   owners,
+  githubAvatars = true,
   onThemeChange,
   onTextSizeChange,
   onHideArchivedNoiseChange,
@@ -75,11 +77,11 @@ export function TopBar({
         {/* Wrapper for logo + org badges. Logo keeps its original overflow:hidden for border-radius. */}
         <div style={{ position: "relative", flexShrink: 0 }}>
           <div className="logo">
-            <img src={authLogin ? `https://github.com/${authLogin}.png?size=80` : appLogo} alt="" />
+            <img src={authLogin && githubAvatars ? `https://github.com/${authLogin}.png?size=80` : appLogo} alt="" referrerPolicy="no-referrer" />
           </div>
           {/* Org badges: positioned relative to wrapper, outside logo's overflow:hidden */}
-          {orgs.length > 0 && orgs.slice(0, 3).map((org, i) => (
-            <img key={org} src={`https://github.com/${org}.png?size=40`} alt={org} title={org}
+          {githubAvatars && orgs.length > 0 && orgs.slice(0, 3).map((org, i) => (
+            <img key={org} src={`https://github.com/${org}.png?size=40`} alt={org} title={org} loading="lazy" referrerPolicy="no-referrer"
               style={{ position: "absolute", bottom: -4, right: -4 + i * 8, width: 20, height: 20, borderRadius: "50%", objectFit: "contain", objectPosition: "55% center", zIndex: 3 - i, border: "1px solid var(--border-soft)", background: "color-mix(in srgb, var(--panel) 85%, transparent)" }} />
           ))}
         </div>

--- a/src/components/modals/RepositoryDetailsModal.tsx
+++ b/src/components/modals/RepositoryDetailsModal.tsx
@@ -197,39 +197,69 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
-
-    async function loadDetails() {
-      setLoading(true);
-      setError("");
-      try {
-        const [detailsResult, issueRefs, codeRefs, dependentRefs, trafficResult] = await Promise.all([
-          fetchRepoDetails(repo.nameWithOwner),
-          fetchMentionIssues(repo.nameWithOwner),
-          fetchMentionCode(repo.nameWithOwner),
-          fetchDependents(repo.nameWithOwner),
-          fetchRepoTraffic(repo.nameWithOwner),
-        ]);
-        if (!cancelled) {
-          setDetails(detailsResult);
-          setMentionIssues(issueRefs.items);
-          setMentionCode(codeRefs.items);
-          setAliases(issueRefs.aliases ?? []);
-          setDependents(dependentRefs.items);
-          setTrafficDetails(trafficResult);
-        }
-      } catch (err) {
-        if (!cancelled) setError((err as Error).message);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
+    const section = activeTab === "overview" || activeTab === "actions" || activeTab === "commits" || activeTab === "milestones" || activeTab === "releases"
+      ? activeTab
+      : null;
+    if (!section) {
+      setLoading(false);
+      return;
     }
+    let cancelled = false;
+    setLoading(true);
+    setError("");
+    void fetchRepoDetails(repo.nameWithOwner, section, refreshKey > 0)
+      .then((result) => {
+        if (!cancelled) setDetails(result);
+      })
+      .catch((err) => {
+        if (!cancelled) setError((err as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [activeTab, repo.nameWithOwner, refreshKey]);
 
-    void loadDetails();
-    return () => {
-      cancelled = true;
-    };
-  }, [repo.nameWithOwner, refreshKey]);
+  useEffect(() => {
+    if (activeTab !== "mentions") return;
+    let cancelled = false;
+    setLoading(true);
+    setError("");
+    void Promise.all([fetchMentionIssues(repo.nameWithOwner), fetchMentionCode(repo.nameWithOwner)])
+      .then(([issueRefs, codeRefs]) => {
+        if (cancelled) return;
+        setMentionIssues(issueRefs.items);
+        setMentionCode(codeRefs.items);
+        setAliases(issueRefs.aliases ?? []);
+      })
+      .catch((err) => { if (!cancelled) setError((err as Error).message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [activeTab, repo.nameWithOwner, refreshKey]);
+
+  useEffect(() => {
+    if (activeTab !== "dependents") return;
+    let cancelled = false;
+    setLoading(true);
+    setError("");
+    void fetchDependents(repo.nameWithOwner)
+      .then((result) => { if (!cancelled) setDependents(result.items); })
+      .catch((err) => { if (!cancelled) setError((err as Error).message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [activeTab, repo.nameWithOwner, refreshKey]);
+
+  useEffect(() => {
+    if (activeTab !== "traffic") return;
+    let cancelled = false;
+    setLoading(true);
+    setError("");
+    void fetchRepoTraffic(repo.nameWithOwner)
+      .then((result) => { if (!cancelled) setTrafficDetails(result); })
+      .catch((err) => { if (!cancelled) setError((err as Error).message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [activeTab, repo.nameWithOwner, refreshKey]);
 
   useEffect(() => {
     setContributorsPage(1);
@@ -398,7 +428,7 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
   const contributors = details?.contributors || [];
   const topics = details?.meta?.topics || [];
   const languages = Object.entries(details?.languages || {}).sort((a, b) => b[1] - a[1]).slice(0, 5);
-  const views = details?.views ?? null;
+  const views = trafficDetails?.views ?? details?.views ?? null;
   const clones = trafficDetails?.clones ?? null;
   const releases = details?.releases ?? [];
   const workflows = details?.workflows ?? [];
@@ -558,7 +588,7 @@ export function RepositoryDetailsModal({ repo, issues, pullRequests, activeTab, 
           <section className="repo-detail-stats" aria-label="Repository stats">
             <div className="repo-detail-stat"><StarIcon /><span>Stars</span><strong>{formatNumber(repo.stargazerCount)}</strong></div>
             <div className="repo-detail-stat"><ForkIcon /><span>Forks</span><strong>{formatNumber(repo.forkCount)}</strong></div>
-            <button className="repo-detail-stat action" onClick={() => onIssuesClick(repo.nameWithOwner)}><IssueIcon /><span>Open issues</span><strong>{formatNumber(issueCountForRepo(issues, repo.nameWithOwner))}</strong></button>
+            <button className="repo-detail-stat action" onClick={() => onIssuesClick(repo.nameWithOwner)}><IssueIcon /><span>Open issues</span><strong>{formatNumber(issueCountForRepo(issues, repo.nameWithOwner, repo.openIssueCount))}</strong></button>
           </section>
 
           <section className="repo-detail-grid">

--- a/src/components/views/RepoGrid.tsx
+++ b/src/components/views/RepoGrid.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { GhIssue, GhRepo, RepoInsight } from "../../types/github";
 import { getLanguageColor } from "../../utils/colors";
 import { formatNumber, formatRelativeTime } from "../../utils/format";
@@ -14,24 +15,52 @@ interface RepoGridProps {
   onIssuesClick: (repo: string) => void;
   onStarsClick: (repo: string) => void;
   onForksClick: (repo: string) => void;
+  onVisibleReposChange?: (repos: string[]) => void;
 }
 
-export function RepoGrid({ repos, issues, insightsByRepo, onRepoClick, onIssuesClick, onStarsClick, onForksClick }: RepoGridProps) {
+export function RepoGrid({ repos, issues, insightsByRepo, onRepoClick, onIssuesClick, onStarsClick, onForksClick, onVisibleReposChange }: RepoGridProps) {
   const { language, t } = useI18n();
+  const gridRef = useRef<HTMLDivElement>(null);
+  const repoKey = repos.map((repo) => repo.nameWithOwner).join("\n");
+
+  useEffect(() => {
+    if (!onVisibleReposChange || !gridRef.current) return;
+    if (typeof IntersectionObserver === "undefined") {
+      onVisibleReposChange(repos.map((repo) => repo.nameWithOwner));
+      return () => onVisibleReposChange([]);
+    }
+    const visible = new Set<string>();
+    const publish = () => onVisibleReposChange(repos.map((repo) => repo.nameWithOwner).filter((repo) => visible.has(repo)));
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        const repo = (entry.target as HTMLElement).dataset.repo;
+        if (!repo) continue;
+        if (entry.isIntersecting) visible.add(repo);
+      }
+      publish();
+    }, { rootMargin: "240px 0px", threshold: 0.01 });
+    for (const card of gridRef.current.querySelectorAll<HTMLElement>("[data-repo]")) observer.observe(card);
+    return () => {
+      observer.disconnect();
+      onVisibleReposChange([]);
+    };
+  }, [repoKey, onVisibleReposChange]);
+
   if (!repos.length) {
     return <div className="empty"><div className="big">{t("empty.reposTitle")}</div><div>{t("empty.tryClearing")}</div></div>;
   }
 
   return (
-    <div className="repos-grid">
+    <div className="repos-grid" ref={gridRef}>
       {repos.map((repo) => {
-        const issueCount = issueCountForRepo(issues, repo.nameWithOwner);
+        const issueCount = issueCountForRepo(issues, repo.nameWithOwner, repo.openIssueCount);
         const primaryLanguage = repo.primaryLanguage?.name;
         const insight = insightsByRepo.get(repo.nameWithOwner);
         return (
           <article
             className="repo-card"
             key={repo.nameWithOwner}
+            data-repo={repo.nameWithOwner}
             tabIndex={0}
             onClick={() => onRepoClick(repo)}
             onKeyDown={(event) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -847,6 +847,10 @@ async function handleProjectMove(req: IncomingMessage, res: ServerResponse): Pro
 async function handleRepoDetails(res: ServerResponse, u: URL): Promise<void> {
   const repo = u.searchParams.get("repo");
   if (!parseRepo(repo) || !repo) return sendJson(res, 400, { ok: false, error: "invalid repo" });
+  const requestedSection = u.searchParams.get("section") ?? "overview";
+  const section = new Set(["overview", "actions", "commits", "milestones", "releases", "traffic", "minimal"]).has(requestedSection)
+    ? requestedSection
+    : "overview";
 
   async function fetchContributors() {
     return restApiPaginate(`/repos/${repo}/contributors?per_page=100&anon=1`);
@@ -875,19 +879,20 @@ async function handleRepoDetails(res: ServerResponse, u: URL): Promise<void> {
     }
   }
 
+  const emptyResult = (data: unknown) => Promise.resolve({ ok: true as const, data });
   const [meta, languages, contributors, commits, workflows, views, releases, repoDigest, security, milestones, community, counts] = await Promise.all([
     ghApiJson(`/repos/${repo}`),
-    ghApiJson(`/repos/${repo}/languages`),
-    fetchContributors(),
-    ghApiJson(`/repos/${repo}/commits?per_page=20`),
-    ghApiJson(`/repos/${repo}/actions/runs?per_page=100`),
-    ghApiJson(`/repos/${repo}/traffic/views`),
-    fetchReleases(),
-    getLatestRepoDigest(repo),
-    fetchRepoSecuritySummary(repo),
-    ghApiJson(`/repos/${repo}/milestones?state=open&per_page=100&sort=due_on&direction=asc`),
-    ghApiJson(`/repos/${repo}/community/profile`),
-    fetchRepoCounts(),
+    section === "overview" ? ghApiJson(`/repos/${repo}/languages`) : emptyResult({}),
+    section === "overview" ? fetchContributors() : emptyResult([]),
+    section === "commits" ? ghApiJson(`/repos/${repo}/commits?per_page=20`) : emptyResult([]),
+    section === "actions" ? ghApiJson(`/repos/${repo}/actions/runs?per_page=100`) : emptyResult({ workflow_runs: [] }),
+    section === "traffic" ? ghApiJson(`/repos/${repo}/traffic/views`) : emptyResult(null),
+    section === "releases" ? fetchReleases() : emptyResult([]),
+    section === "overview" ? getLatestRepoDigest(repo) : Promise.resolve(null),
+    section === "overview" ? fetchRepoSecuritySummary(repo) : Promise.resolve(null),
+    section === "milestones" ? ghApiJson(`/repos/${repo}/milestones?state=open&per_page=100&sort=due_on&direction=asc`) : emptyResult([]),
+    section === "overview" ? ghApiJson(`/repos/${repo}/community/profile`) : emptyResult(null),
+    section === "overview" ? fetchRepoCounts() : Promise.resolve({ branches: null, discussions: null }),
   ]);
 
   const normalizedReleases = releases.ok

--- a/src/server/dashboardData.ts
+++ b/src/server/dashboardData.ts
@@ -1,6 +1,5 @@
 import type { GhIssue, GhPullRequest, GhRepo } from "../types/github";
 import { getActive as getActiveAccount } from "./accountStore";
-import { recordDailyDigest } from "./digests";
 import { AuthRequiredError } from "./githubClient";
 import { getProviderForAccount } from "./providers/registry";
 import type { Account, OwnersOutcome, Provider } from "./providers/types";
@@ -22,7 +21,6 @@ const TTL_MS = 5 * 60 * 1000;
 
 interface Memoized<T extends { ok: boolean }> {
   get(forceFresh: boolean): Promise<T>;
-  peek(): T | null;
   invalidate(): void;
 }
 
@@ -43,9 +41,6 @@ function memoize<T extends { ok: boolean }>(ttlMs: number, fetcher: () => Promis
         }
       })();
       return inflight;
-    },
-    peek() {
-      return cache && cache.expiresAt > Date.now() ? cache.value : null;
     },
     invalidate() {
       cache = null;
@@ -87,9 +82,7 @@ const reposStore = memoize<ReposResult>(TTL_MS, async (): Promise<ReposResult> =
     } catch {
       // Snapshot/history is best-effort.
     }
-    const result: ReposResult = { ok: true, repos, owners: ownersResult.owners, fetchedAt: new Date().toISOString() };
-    maybeRecordDigest(result, issuesStore.peek());
-    return result;
+    return { ok: true, repos, owners: ownersResult.owners, fetchedAt: new Date().toISOString() };
   } catch (error: unknown) {
     if (error instanceof AuthRequiredError) return authFail();
     return genericFail(error);
@@ -103,9 +96,7 @@ const issuesStore = memoize<IssuesResult>(TTL_MS, async (): Promise<IssuesResult
     const active = await resolveActive();
     if (!active) return authFail();
     const issues = await active.provider.listIssues(active.account, ownersResult.owners);
-    const result: IssuesResult = { ok: true, issues, owners: ownersResult.owners, fetchedAt: new Date().toISOString() };
-    maybeRecordDigest(reposStore.peek(), result);
-    return result;
+    return { ok: true, issues, owners: ownersResult.owners, fetchedAt: new Date().toISOString() };
   } catch (error: unknown) {
     if (error instanceof AuthRequiredError) return authFail();
     return genericFail(error);
@@ -125,19 +116,6 @@ const pullRequestsStore = memoize<PullRequestsResult>(TTL_MS, async (): Promise<
     return genericFail(error);
   }
 });
-
-let digestRecordedFor: { reposAt: string; issuesAt: string } | null = null;
-
-function maybeRecordDigest(repos: ReposResult | null, issues: IssuesResult | null): void {
-  if (!repos || !repos.ok || !issues || !issues.ok) return;
-  if (digestRecordedFor && digestRecordedFor.reposAt === repos.fetchedAt && digestRecordedFor.issuesAt === issues.fetchedAt) {
-    return;
-  }
-  digestRecordedFor = { reposAt: repos.fetchedAt, issuesAt: issues.fetchedAt };
-  void recordDailyDigest(repos.repos, issues.issues).catch(() => {
-    digestRecordedFor = null;
-  });
-}
 
 export function getReposCached(forceFresh: boolean): Promise<ReposResult> {
   if (forceFresh) ownersStore.invalidate();
@@ -159,5 +137,4 @@ export function invalidateDataCache(): void {
   reposStore.invalidate();
   issuesStore.invalidate();
   pullRequestsStore.invalidate();
-  digestRecordedFor = null;
 }

--- a/src/server/digests.ts
+++ b/src/server/digests.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { DailyRepoDigest, GhIssue, GhRepo } from "../types/github";
 import { buildDailyDigestEntries, buildDailyDigestRecord, buildPeriodDigestEntries, type DailyDigestRecord, type DigestPeriod } from "../utils/digests";
 import { DATA_DIR, DIGESTS_PATH } from "./config";
+import { getIssuesCached, getReposCached } from "./dashboardData";
 import { sendJsonCacheable } from "./http";
 import { fetchRepoSecuritySummary } from "./securityAlerts";
 import { maybeGenerateOpenAIDigest } from "./openaiDigest";
@@ -46,7 +47,10 @@ export async function recordDailyDigest(repos: GhRepo[], issues: GhIssue[]): Pro
       }
     }),
   );
-  const today = buildDailyDigestRecord(activeRepos, issues, Date.now(), new Map(securityEntries.map(([repo, summary]) => [repo, summary])));
+  const today = buildDailyDigestRecord(activeRepos, issues, Date.now(), new Map(securityEntries.map(([repo, summary]) => [repo, {
+    securityAlertsCount: summary.totalOpen,
+    securityAlertsUnavailable: summary.unavailable,
+  }])));
   const existing = digests.find((entry) => entry.date === today.date);
   if (existing) {
     Object.assign(existing, today);
@@ -65,6 +69,16 @@ function parsePeriod(value: string | null): DigestPeriod {
 
 export async function handleDailyDigests(req: IncomingMessage, res: ServerResponse): Promise<void> {
   const records = await loadDigests();
+  const today = new Date().toISOString().slice(0, 10);
+
+  // Building a digest can fan out into security API requests for every active
+  // repository. Do it only when the digest view is explicitly requested, never
+  // as a side effect of loading ordinary dashboard data.
+  if (records[records.length - 1]?.date !== today) {
+    const [repos, issues] = await Promise.all([getReposCached(false), getIssuesCached(false)]);
+    if (repos.ok && issues.ok) await recordDailyDigest(repos.repos, issues.issues);
+  }
+
   const latest = records[records.length - 1];
   if (latest && !latest.ai) {
     try {

--- a/src/server/providers/forgejoData.ts
+++ b/src/server/providers/forgejoData.ts
@@ -36,6 +36,7 @@ interface ForgejoRepo {
   stars_count?: number;
   stargazers_count?: number;
   forks_count: number;
+  open_issues_count?: number;
   language?: string | null;
   updated_at: string;
   pushed_at?: string;
@@ -188,6 +189,7 @@ function normalizeRepo(raw: ForgejoRepo): GhRepo {
     description: raw.description,
     stargazerCount: raw.stars_count ?? raw.stargazers_count ?? 0,
     forkCount: raw.forks_count ?? 0,
+    openIssueCount: raw.open_issues_count ?? 0,
     primaryLanguage: raw.language ? { name: raw.language } : null,
     updatedAt: raw.updated_at,
     pushedAt: raw.pushed_at ?? raw.updated_at,

--- a/src/server/providers/github.ts
+++ b/src/server/providers/github.ts
@@ -311,6 +311,7 @@ export class GitHubProvider implements Provider {
           description: node.description,
           stargazerCount: node.stargazerCount,
           forkCount: node.forkCount,
+          openIssueCount: node.issues.totalCount,
           primaryLanguage: node.primaryLanguage,
           updatedAt: node.updatedAt,
           pushedAt: node.pushedAt,
@@ -506,6 +507,7 @@ query($owner: String!, $cursor: String) {
         nameWithOwner name
         owner { login avatarUrl }
         description stargazerCount forkCount
+        issues(states: OPEN) { totalCount }
         primaryLanguage { name }
         updatedAt pushedAt
         visibility
@@ -614,6 +616,7 @@ interface RepoNode {
   description: string | null;
   stargazerCount: number;
   forkCount: number;
+  issues: { totalCount: number };
   primaryLanguage: { name: string } | null;
   updatedAt: string;
   pushedAt: string;

--- a/src/server/repoInsights.ts
+++ b/src/server/repoInsights.ts
@@ -74,25 +74,28 @@ const INSIGHTS_TTL_MS = 15 * 60 * 1000;
 let insightsCache: { value: { ok: true; generatedAt: string; insights: RepoInsight[] }; expiresAt: number } | null = null;
 let inflight: Promise<{ ok: true; generatedAt: string; insights: RepoInsight[] } | { ok: false; error: string }> | null = null;
 
+async function buildRepoInsights(forceFresh: boolean, requestedRepos?: Set<string>) {
+  const [repos, issues] = await Promise.all([getReposCached(forceFresh), getIssuesCached(forceFresh)]);
+  if (!repos.ok) return repos;
+  if (!issues.ok) return issues;
+
+  const activeRepos = repos.repos.filter((repo) => !repo.isArchived && (!requestedRepos || requestedRepos.has(repo.nameWithOwner)));
+  const insights = await mapWithConcurrency(activeRepos, 6, async (repo) => fetchInsightForRepo(repo, issues.issues));
+  return {
+    ok: true as const,
+    generatedAt: new Date().toISOString(),
+    insights: insights.sort((a, b) => a.healthScore - b.healthScore || b.issueCount - a.issueCount || a.repo.localeCompare(b.repo)),
+  };
+}
+
 export async function getRepoInsightsCached(forceFresh: boolean) {
   if (!forceFresh && insightsCache && insightsCache.expiresAt > Date.now()) return insightsCache.value;
   if (inflight) return inflight;
 
-  inflight = (async () => {
-    const [repos, issues] = await Promise.all([getReposCached(forceFresh), getIssuesCached(forceFresh)]);
-    if (!repos.ok) return repos;
-    if (!issues.ok) return issues;
-
-    const activeRepos = repos.repos.filter((repo) => !repo.isArchived);
-    const insights = await mapWithConcurrency(activeRepos, 6, async (repo) => fetchInsightForRepo(repo, issues.issues));
-    const result = {
-      ok: true as const,
-      generatedAt: new Date().toISOString(),
-      insights: insights.sort((a, b) => a.healthScore - b.healthScore || b.issueCount - a.issueCount || a.repo.localeCompare(b.repo)),
-    };
-    insightsCache = { value: result, expiresAt: Date.now() + INSIGHTS_TTL_MS };
+  inflight = buildRepoInsights(forceFresh).then((result) => {
+    if (result.ok) insightsCache = { value: result, expiresAt: Date.now() + INSIGHTS_TTL_MS };
     return result;
-  })().finally(() => {
+  }).finally(() => {
     inflight = null;
   });
 
@@ -101,6 +104,9 @@ export async function getRepoInsightsCached(forceFresh: boolean) {
 
 export async function handleRepoInsights(req: IncomingMessage, res: ServerResponse, u: URL): Promise<void> {
   const fresh = u.searchParams.get("fresh") === "1";
-  const payload = await getRepoInsightsCached(fresh);
+  const requestedRepos = new Set(u.searchParams.getAll("repo").filter(Boolean));
+  const payload = requestedRepos.size
+    ? await buildRepoInsights(fresh, requestedRepos)
+    : await getRepoInsightsCached(fresh);
   sendJsonCacheable(req, res, payload.ok ? 200 : 500, payload);
 }

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -95,6 +95,7 @@ export interface GhRepo {
   description: string | null;
   stargazerCount: number;
   forkCount: number;
+  openIssueCount?: number;
   primaryLanguage: { name: string } | null;
   updatedAt: string;
   pushedAt: string;

--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -41,8 +41,9 @@ export interface RepoFilters {
 
 export type FacetValue = number | { count: number; color?: string };
 
-export function issueCountForRepo(issues: GhIssue[], nameWithOwner: string): number {
-  return issues.filter((issue) => issue.repository.nameWithOwner === nameWithOwner).length;
+export function issueCountForRepo(issues: GhIssue[], nameWithOwner: string, fallback = 0): number {
+  const count = issues.filter((issue) => issue.repository.nameWithOwner === nameWithOwner).length;
+  return count || fallback;
 }
 
 export function pullRequestCountForRepo(prs: GhPullRequest[], nameWithOwner: string): number {
@@ -178,7 +179,7 @@ export function filterRepos(repos: GhRepo[], issues: GhIssue[], filters: RepoFil
     if (!filters.includeForks && repo.isFork) return false;
     if (!filters.includeArchived && repo.isArchived) return false;
     if (!query) return true;
-    return [repo.nameWithOwner, repo.description || "", language, String(issueCountForRepo(issues, repo.nameWithOwner))]
+    return [repo.nameWithOwner, repo.description || "", language, String(issueCountForRepo(issues, repo.nameWithOwner, repo.openIssueCount))]
       .join(" ")
       .toLowerCase()
       .includes(query);
@@ -278,7 +279,7 @@ export function sortIssues(issues: GhIssue[], sort: string): GhIssue[] {
 export function sortRepos(repos: GhRepo[], issues: GhIssue[], sort: string, insightsByRepo?: Map<string, RepoInsight>): GhRepo[] {
   const sorted = [...repos];
   sorted.sort((a, b) => {
-    const issueDelta = issueCountForRepo(issues, b.nameWithOwner) - issueCountForRepo(issues, a.nameWithOwner);
+    const issueDelta = issueCountForRepo(issues, b.nameWithOwner, b.openIssueCount) - issueCountForRepo(issues, a.nameWithOwner, a.openIssueCount);
     const healthDelta = (insightsByRepo?.get(b.nameWithOwner)?.healthScore ?? 0) - (insightsByRepo?.get(a.nameWithOwner)?.healthScore ?? 0);
     if (sort === "stars_asc") return a.stargazerCount - b.stargazerCount;
     if (sort === "forks_desc") return b.forkCount - a.forkCount;

--- a/src/utils/dataRequirements.ts
+++ b/src/utils/dataRequirements.ts
@@ -1,0 +1,55 @@
+export type DashboardTab = "inbox" | "repos" | "issues" | "prs" | "kanban" | "insights" | "alerts" | "ci" | "digests";
+
+export type DashboardResource = "repos" | "issues" | "prs";
+
+/**
+ * Returns only the base provider datasets needed to render the current view.
+ * Expensive, view-specific resources (notifications, insights, CI and digests)
+ * are loaded by their own effects when that view is active.
+ */
+export function dataRequirementsForTab(
+  tab: DashboardTab,
+  hasRepositoryRoute = false,
+  repositoryDetail?: "issues" | "pull-requests" | string,
+): Set<DashboardResource> {
+  const resources = new Set<DashboardResource>();
+
+  switch (tab) {
+    case "inbox":
+      resources.add("repos");
+      resources.add("issues");
+      resources.add("prs");
+      break;
+    case "repos":
+      resources.add("repos");
+      break;
+    case "insights":
+    case "alerts":
+      resources.add("repos");
+      resources.add("issues");
+      break;
+    case "issues":
+      resources.add("repos");
+      resources.add("issues");
+      break;
+    case "prs":
+      resources.add("repos");
+      resources.add("prs");
+      break;
+    case "ci":
+      resources.add("repos");
+      break;
+    case "kanban":
+    case "digests":
+      break;
+  }
+
+  if (hasRepositoryRoute) resources.add("repos");
+  if (repositoryDetail === "issues") resources.add("issues");
+  if (repositoryDetail === "pull-requests") resources.add("prs");
+  return resources;
+}
+
+export function allDashboardResources(): Set<DashboardResource> {
+  return new Set(["repos", "issues", "prs"]);
+}

--- a/tests/utils/dataRequirements.test.ts
+++ b/tests/utils/dataRequirements.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { allDashboardResources, dataRequirementsForTab } from "../../src/utils/dataRequirements";
+
+describe("dataRequirementsForTab", () => {
+  it("loads all inbox datasets because inbox combines them", () => {
+    expect([...dataRequirementsForTab("inbox")]).toEqual(["repos", "issues", "prs"]);
+  });
+
+  it("does not load unrelated datasets for focused views", () => {
+    expect([...dataRequirementsForTab("repos")]).toEqual(["repos"]);
+    expect([...dataRequirementsForTab("issues")]).toEqual(["repos", "issues"]);
+    expect([...dataRequirementsForTab("prs")]).toEqual(["repos", "prs"]);
+    expect([...dataRequirementsForTab("ci")]).toEqual(["repos"]);
+    expect([...dataRequirementsForTab("digests")]).toEqual([]);
+    expect([...dataRequirementsForTab("kanban")]).toEqual([]);
+  });
+
+  it("loads only datasets used by a deep-linked repository tab", () => {
+    expect([...dataRequirementsForTab("digests", true)]).toEqual(["repos"]);
+    expect([...dataRequirementsForTab("repos", true, "issues")]).toEqual(["repos", "issues"]);
+    expect([...dataRequirementsForTab("repos", true, "pull-requests")]).toEqual(["repos", "prs"]);
+  });
+
+  it("provides all resources only for explicitly global features", () => {
+    expect([...allDashboardResources()]).toEqual(["repos", "issues", "prs"]);
+  });
+});


### PR DESCRIPTION
## Summary

- load repositories, issues, pull requests, notifications, CI, digests, and insights only for the active view
- limit repository-card insights to cards near the viewport and merge targeted responses into the client cache
- fetch repository-detail data per active tab instead of eagerly loading every provider-backed section
- generate daily digest security data only when the digest view is requested
- include open issue counts in repository responses so repository cards do not require the full issue dataset
- avoid GitHub avatar requests for Forgejo accounts and defer hidden sidebar resources
- preserve in-flight requests across view transitions while cancelling all account-scoped work on account changes and logout

## Tests

- `npm test` (87 tests pass)
- `npm run build`
- `git diff --check`

## Typecheck

`npm run typecheck` still reports pre-existing errors in `IssueList.tsx`, `PullRequestList.tsx`, `TriageWorkspace.tsx`, `openaiDigest.ts`, and `tests/utils/colors.test.ts`.
