### PR TITLE
feat: add dashboard load diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The server reads its configuration from environment variables:
 | `PORT`                 | no       | `8765`                                         | Port the server listens on                       |
 | `OPENAI_API_KEY`       | no       | —                                              | Enables AI-generated daily digest narratives     |
 | `OPENAI_DIGEST_MODEL`  | no       | `gpt-4.1-mini`                                 | Model used for digest narratives                 |
+| `GITDECK_DIAGNOSTICS`  | no       | —                                              | Set to `1` to log provider call durations        |
 
 ### Authentication modes
 
@@ -237,6 +238,16 @@ npm run typecheck # tsc --noEmit
 ```
 
 Tests live under `tests/` and mirror the structure of `src/` (see [AGENTS.md](AGENTS.md)).
+
+### Load diagnostics
+
+Base dashboard loads retain the latest 50 measurements in memory, including time to first content, total duration, cache hits, deduplicated requests, and network requests. In the browser console, enable per-load logging with:
+
+```js
+localStorage.setItem("gh-dash.diagnostics", "1")
+```
+
+Provider-side call counts and timings are available from `GET /api/diagnostics/provider-metrics`. Set `GITDECK_DIAGNOSTICS=1` to also log every measured provider operation on the server.
 
 ## Project layout
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import {
-  AuthRequiredClientError,
   fetchAuthStatus,
   fetchCIHealth,
   fetchDailyDigests,
-  fetchIssues,
   fetchNotifications,
-  fetchPullRequests,
   fetchRepoInsights,
-  fetchRepos,
   logoutAuth,
   markAllNotificationsRead,
   markNotificationRead,
@@ -40,16 +36,11 @@ import type {
   DailyDigestEntry,
   DailyDigestsData,
   DigestPeriod,
-  GhIssue,
   GhNotification,
-  GhPullRequest,
   GhRepo,
-  IssuesData,
-  PullRequestsData,
   RepoCIHealth,
   RepoInsight,
   RepoInsightsData,
-  ReposData,
 } from "./types/github";
 import { buildInboxItems, INBOX_MAILBOXES, matchesInboxMailbox, mergeNotifications, type InboxMailbox } from "./utils/inbox";
 import {
@@ -67,13 +58,14 @@ import {
   type RepoFilters,
 } from "./utils/dashboard";
 import { clampPage } from "./utils/pagination";
-import { allDashboardResources, dataRequirementsForTab, type DashboardResource } from "./utils/dataRequirements";
+import { dataRequirementsForTab } from "./utils/dataRequirements";
 import { getOwner } from "./utils/repository";
 import { formatNumber } from "./utils/format";
-import { clearStatsCache, readStatsCache, writeStatsCache } from "./utils/statsCache";
+import { clearStatsCache } from "./utils/statsCache";
 import { clearFiltersCache, hydrateFilters, readFiltersCache, writeFiltersCache } from "./utils/filtersCache";
 import { useI18n } from "./i18n/I18nProvider";
 import { useAccounts, useCapability } from "./contexts/AccountContext";
+import { useDashboardData } from "./hooks/useDashboardData";
 
 type Tab = "inbox" | "repos" | "issues" | "prs" | "kanban" | "insights" | "alerts" | "ci" | "digests";
 type Theme = "dark" | "light" | "auto";
@@ -184,19 +176,12 @@ export function App() {
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [authLogin, setAuthLogin] = useState<string | null>(null);
   const [authMode, setAuthMode] = useState<"device" | "gh-cli" | "token">("device");
-  const [issues, setIssues] = useState<GhIssue[]>([]);
-  const [pullRequests, setPullRequests] = useState<GhPullRequest[]>([]);
-  const [repos, setRepos] = useState<GhRepo[]>([]);
-  const [owners, setOwners] = useState<string[]>([]);
   const [repoInsights, setRepoInsights] = useState<RepoInsight[]>([]);
   const [visibleRepoInsightNames, setVisibleRepoInsightNames] = useState<string[]>([]);
   const [dailyDigests, setDailyDigests] = useState<DailyDigestEntry[]>([]);
   const [digestPeriod, setDigestPeriod] = useState<DigestPeriod>(() => (localStorage.getItem("gh-dash.digestPeriod") as DigestPeriod) || "day");
   const [ciHealth, setCiHealth] = useState<RepoCIHealth[]>([]);
-  const [fetchedAt, setFetchedAt] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [dataStale, setDataStale] = useState(false);
-  const [error, setError] = useState("");
+  const [boardCount, setBoardCount] = useState(0);
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [contributorsOpen, setContributorsOpen] = useState(false);
   const [changelogOpen, setChangelogOpen] = useState(false);
@@ -225,98 +210,39 @@ export function App() {
   const [issuePageSize, setIssuePageSize] = useState(Number(localStorage.getItem("gh-dash.issuesPageSize")) || 20);
   const [prPageSize, setPrPageSize] = useState(Number(localStorage.getItem("gh-dash.prsPageSize")) || 20);
   const [repoPageSize, setRepoPageSize] = useState(Number(localStorage.getItem("gh-dash.reposPageSize")) || 20);
-  const abortControllersRef = useRef(new Set<AbortController>());
-  const activeLoadsRef = useRef(0);
-  const loadedAccountRef = useRef<string | null>(null);
-
-  const loadData = useCallback((resources: Set<DashboardResource>, fresh = false) => {
-    const controller = new AbortController();
-    abortControllersRef.current.add(controller);
-    setError("");
-
-    const cachedRepos = resources.has("repos") ? peek<ReposData>(CACHE_KEY.repos) : null;
-    if (cachedRepos) {
-      setRepos(cachedRepos.repos);
-      setOwners(cachedRepos.owners);
-      setFetchedAt(cachedRepos.fetchedAt);
-    }
-    const cachedIssues = resources.has("issues") ? peek<IssuesData>(CACHE_KEY.issues) : null;
-    if (cachedIssues) setIssues(cachedIssues.issues);
-    const cachedPrs = resources.has("prs") ? peek<PullRequestsData>(CACHE_KEY.prs) : null;
-    if (cachedPrs) setPullRequests(cachedPrs.pullRequests);
-
-    // Local persisted data costs no provider requests and keeps previously visited
-    // tabs warm after a browser refresh.
-    if (!cachedRepos && !cachedIssues && !cachedPrs) {
-      const persisted = readStatsCache();
-      if (persisted) {
-        setRepos(persisted.repos as GhRepo[]);
-        setOwners(persisted.owners);
-        setIssues(persisted.issues as GhIssue[]);
-        setPullRequests(persisted.pullRequests as GhPullRequest[]);
-        if (persisted.fetchedAt) setFetchedAt(persisted.fetchedAt);
-      }
-    }
-
-    let pending = resources.size;
-    if (!pending) {
-      abortControllersRef.current.delete(controller);
-      return;
-    }
-    activeLoadsRef.current += 1;
-    setLoading(true);
-    setDataStale(true);
-    const finish = () => {
-      pending -= 1;
-      if (pending > 0 || !abortControllersRef.current.has(controller)) return;
-      abortControllersRef.current.delete(controller);
-      activeLoadsRef.current = Math.max(0, activeLoadsRef.current - 1);
-      if (activeLoadsRef.current === 0) {
-        setLoading(false);
-        setDataStale(false);
-      }
-    };
-    const handleFailure = (err: unknown) => {
-      if (controller.signal.aborted) return;
-      if (err instanceof AuthRequiredClientError) {
-        setAuthState("anonymous");
-        setAuthLogin(null);
-        return;
-      }
-      if ((err as Error).name === "AbortError") return;
-      setError((err as Error).message);
-    };
-
-    if (resources.has("repos")) {
-      void swr<ReposData>(CACHE_KEY.repos, (signal) => fetchRepos(fresh, signal), {
-        fresh,
-        signal: controller.signal,
-      }).promise.then((data) => {
-        if (controller.signal.aborted) return;
-        setRepos(data.repos);
-        setOwners(data.owners);
-        setFetchedAt(data.fetchedAt);
-      }, handleFailure).finally(finish);
-    }
-
-    if (resources.has("issues")) {
-      void swr<IssuesData>(CACHE_KEY.issues, (signal) => fetchIssues(fresh, signal), {
-        fresh,
-        signal: controller.signal,
-      }).promise.then((data) => {
-        if (!controller.signal.aborted) setIssues(data.issues);
-      }, handleFailure).finally(finish);
-    }
-
-    if (resources.has("prs")) {
-      void swr<PullRequestsData>(CACHE_KEY.prs, (signal) => fetchPullRequests(fresh, signal), {
-        fresh,
-        signal: controller.signal,
-      }).promise.then((data) => {
-        if (!controller.signal.aborted) setPullRequests(data.pullRequests);
-      }, handleFailure).finally(finish);
-    }
+  const handleBaseAuthRequired = useCallback(() => {
+    setAuthState("anonymous");
+    setAuthLogin(null);
   }, []);
+  const handleBaseAccountChange = useCallback(() => {
+    setRepoInsights([]);
+    setDailyDigests([]);
+    setCiHealth([]);
+    setBoardCount(0);
+    setNotifications([]);
+  }, []);
+  const {
+    issues,
+    pullRequests,
+    repos,
+    owners,
+    fetchedAt,
+    loading,
+    dataStale,
+    error,
+    loadData,
+    loadAll,
+    resetData,
+  } = useDashboardData({
+    authenticated: authState === "authenticated",
+    accountsLoading,
+    accountKey: activeAccountId ?? authLogin,
+    tab,
+    routeRepoName,
+    repositoryDetail: repoDetailTab,
+    onAuthRequired: handleBaseAuthRequired,
+    onAccountChange: handleBaseAccountChange,
+  });
 
   useEffect(() => {
     void fetchAuthStatus()
@@ -333,56 +259,9 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    if (authState !== "authenticated") {
-      loadedAccountRef.current = null;
-      return;
-    }
-    if (accountsLoading) return;
-
-    const accountKey = activeAccountId ?? authLogin ?? "authenticated";
-    const accountChanged = loadedAccountRef.current !== null && loadedAccountRef.current !== accountKey;
-    if (accountChanged) {
-      for (const controller of abortControllersRef.current) controller.abort();
-      abortControllersRef.current.clear();
-      activeLoadsRef.current = 0;
-      setLoading(false);
-      setDataStale(false);
-      setIssues([]);
-      setPullRequests([]);
-      setRepos([]);
-      setOwners([]);
-      setRepoInsights([]);
-      setDailyDigests([]);
-      setCiHealth([]);
-      setNotifications([]);
-      setFetchedAt("");
-      clearStatsCache();
-    }
-    loadedAccountRef.current = accountKey;
-    loadData(dataRequirementsForTab(tab, Boolean(routeRepoName), repoDetailTab), accountChanged);
-  }, [authState, accountsLoading, activeAccountId, authLogin, tab, routeRepoName, repoDetailTab, loadData]);
-
-  useEffect(() => {
     if (authState !== "authenticated" || !paletteOpen) return;
-    loadData(allDashboardResources());
-  }, [authState, paletteOpen, loadData]);
-
-  useEffect(() => () => {
-    for (const controller of abortControllersRef.current) controller.abort();
-    abortControllersRef.current.clear();
-  }, []);
-
-  // Persist dashboard data to localStorage for instant display on next page load
-  useEffect(() => {
-    if (repos.length === 0 && issues.length === 0 && pullRequests.length === 0) return;
-    writeStatsCache({
-      repos,
-      owners,
-      issues,
-      pullRequests,
-      fetchedAt,
-    });
-  }, [repos, owners, issues, pullRequests, fetchedAt]);
+    loadAll();
+  }, [authState, paletteOpen, loadAll]);
 
   useEffect(() => {
     if (authState !== "authenticated") return;
@@ -422,9 +301,7 @@ export function App() {
   }, [digestPeriod]);
 
   async function handleLogout() {
-    for (const controller of abortControllersRef.current) controller.abort();
-    abortControllersRef.current.clear();
-    activeLoadsRef.current = 0;
+    resetData();
     try {
       await logoutAuth();
     } catch {
@@ -435,14 +312,10 @@ export function App() {
     clearFiltersCache();
     setAuthState("anonymous");
     setAuthLogin(null);
-    setIssues([]);
-    setPullRequests([]);
-    setRepos([]);
-    setOwners([]);
     setRepoInsights([]);
     setDailyDigests([]);
     setCiHealth([]);
-    setFetchedAt("");
+    setBoardCount(0);
   }
 
   useEffect(() => {
@@ -789,7 +662,7 @@ export function App() {
     { key: "ci" as const, label: t("tabs.ci"), count: ciHealth.length, icon: <PulseIcon /> },
     { key: "digests" as const, label: t("tabs.digest"), count: dailyDigests.length, icon: <PulseIcon /> },
     ...(projectsEnabled
-      ? [{ key: "kanban" as const, label: t("tabs.board"), count: "—", icon: <BoardIcon /> }]
+      ? [{ key: "kanban" as const, label: t("tabs.board"), count: boardCount, icon: <BoardIcon /> }]
       : []),
   ];
 
@@ -1042,7 +915,7 @@ export function App() {
             </div>
           ) : null}
 
-          {tab === "kanban" && projectsEnabled ? <KanbanView /> : null}
+          {tab === "kanban" && projectsEnabled ? <KanbanView onCountChange={setBoardCount} /> : null}
         </main>
       </div>
       <Footer
@@ -1056,7 +929,7 @@ export function App() {
           pullRequests={pullRequests}
           onNavigateTab={(next) => navigateTab(next)}
           onOpenRepo={(repo) => openRepoModal(repo)}
-          onRefresh={() => loadData(allDashboardResources(), true)}
+          onRefresh={() => loadAll(true)}
           onToggleTheme={cycleTheme}
           onClose={() => setPaletteOpen(false)}
         />

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -9,9 +9,12 @@ const store = new Map<string, CacheEntry<unknown>>();
 const inflight = new Map<string, Promise<unknown>>();
 const etagStore = new Map<string, string>();
 
+export type SwrSource = "cache" | "inflight" | "network";
+
 export interface SwrResult<T> {
   cached: T | null;
   fresh: boolean;
+  source: SwrSource;
   promise: Promise<T>;
 }
 
@@ -62,21 +65,22 @@ export function swr<T>(
   const cached = peek<T>(key);
 
   if (!fresh && cached !== null && isFresh(key)) {
-    return { cached, fresh: true, promise: Promise.resolve(cached) };
+    return { cached, fresh: true, source: "cache", promise: Promise.resolve(cached) };
   }
 
   if (!fresh) {
     const existing = inflight.get(key) as Promise<T> | undefined;
-    if (existing) return { cached, fresh: false, promise: existing };
+    if (existing) return { cached, fresh: false, source: "inflight", promise: existing };
   }
 
   const promise = runFetch();
   if (!fresh) inflight.set(key, promise);
-  return { cached, fresh: false, promise };
+  return { cached, fresh: false, source: "network", promise };
 
   async function runFetch(): Promise<T> {
     try {
       const value = await fetcher(signal);
+      if (signal?.aborted) throw new DOMException("The operation was aborted", "AbortError");
       set(key, value, ttlMs);
       return value;
     } finally {

--- a/src/components/SidebarControls.tsx
+++ b/src/components/SidebarControls.tsx
@@ -190,10 +190,10 @@ export function SidebarControls({
 
   if (inboxMode && inbox) {
     return (
-      <aside className="sidebar" id="sidebar">
-        <div className="side-head">
+      <aside className="sidebar inbox-sidebar" id="sidebar">
+        <div className="side-head inbox-side-head">
           <h2>{t("sidebar.mailboxes")}</h2>
-          <span className="reset" style={{ pointerEvents: "none" }}>{formatNumber(inbox.totalCount)}</span>
+          <span className="mailbox-total" aria-label={`${t("sidebar.mailboxes")}: ${formatNumber(inbox.totalCount)}`}>{formatNumber(inbox.totalCount)}</span>
           <button className="side-close" aria-label={t("common.closeFilters")} onClick={onClose}><CloseIcon /></button>
         </div>
         <div className="search-wrap">
@@ -208,9 +208,10 @@ export function SidebarControls({
             const active = inbox.mailbox === entry.key;
             return (
               <button
-                className={`mailbox-item ${active ? "active" : ""}`}
+                className={`mailbox-item${active ? " active" : ""}${count === 0 ? " empty" : ""}`}
                 key={entry.key}
                 type="button"
+                aria-pressed={active}
                 onClick={() => inbox.onMailboxChange(entry.key)}
               >
                 <span>{t(`mailbox.${entry.key}`)}</span>

--- a/src/components/views/KanbanView.tsx
+++ b/src/components/views/KanbanView.tsx
@@ -19,7 +19,11 @@ function statusValueOf(item: ProjectItem, fieldId: string) {
   return (item.fieldValues?.nodes || []).find((value) => value.__typename === "ProjectV2ItemFieldSingleSelectValue" && value.field?.id === fieldId);
 }
 
-export function KanbanView() {
+interface KanbanViewProps {
+  onCountChange?: (count: number) => void;
+}
+
+export function KanbanView({ onCountChange }: KanbanViewProps) {
   const boardRef = useRef<HTMLDivElement>(null);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [project, setProject] = useState<ProjectDetails | null>(null);
@@ -57,6 +61,10 @@ export function KanbanView() {
   useEffect(() => {
     void loadProjects();
   }, []);
+
+  useEffect(() => {
+    onCountChange?.(projects.length);
+  }, [onCountChange, projects.length]);
 
   useEffect(() => {
     document.body.classList.toggle("board-focus", boardFullscreen);

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  AuthRequiredClientError,
+  fetchIssues,
+  fetchPullRequests,
+  fetchRepos,
+} from "../api/github";
+import { invalidate, peek, swr } from "../api/cache";
+import type {
+  GhIssue,
+  GhPullRequest,
+  GhRepo,
+  IssuesData,
+  PullRequestsData,
+  ReposData,
+} from "../types/github";
+import {
+  allDashboardResources,
+  dataRequirementsForTab,
+  type DashboardResource,
+  type DashboardTab,
+} from "../utils/dataRequirements";
+import { beginDashboardLoad } from "../utils/loadDiagnostics";
+import { clearStatsCache, readStatsCache, writeStatsCache } from "../utils/statsCache";
+
+const CACHE_KEY = {
+  repos: "/api/repos",
+  issues: "/api/issues",
+  prs: "/api/prs",
+} as const;
+
+interface UseDashboardDataOptions {
+  authenticated: boolean;
+  accountsLoading: boolean;
+  accountKey: string | null;
+  tab: DashboardTab;
+  routeRepoName: string;
+  repositoryDetail?: string;
+  onAuthRequired(): void;
+  onAccountChange?(): void;
+}
+
+export interface DashboardDataState {
+  issues: GhIssue[];
+  pullRequests: GhPullRequest[];
+  repos: GhRepo[];
+  owners: string[];
+  fetchedAt: string;
+  loading: boolean;
+  dataStale: boolean;
+  error: string;
+  loadData(resources: Set<DashboardResource>, fresh?: boolean): void;
+  loadAll(fresh?: boolean): void;
+  resetData(): void;
+}
+
+/** Owns base dashboard resource loading, cancellation, caching and persistence. */
+export function useDashboardData(options: UseDashboardDataOptions): DashboardDataState {
+  const {
+    authenticated,
+    accountsLoading,
+    accountKey,
+    tab,
+    routeRepoName,
+    repositoryDetail,
+    onAuthRequired,
+    onAccountChange,
+  } = options;
+  const [issues, setIssues] = useState<GhIssue[]>([]);
+  const [pullRequests, setPullRequests] = useState<GhPullRequest[]>([]);
+  const [repos, setRepos] = useState<GhRepo[]>([]);
+  const [owners, setOwners] = useState<string[]>([]);
+  const [fetchedAt, setFetchedAt] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [dataStale, setDataStale] = useState(false);
+  const [error, setError] = useState("");
+  const abortControllersRef = useRef(new Set<AbortController>());
+  const activeLoadsRef = useRef(0);
+  const loadedAccountRef = useRef<string | null>(null);
+  const activeViewRef = useRef(tab);
+  const onAuthRequiredRef = useRef(onAuthRequired);
+  const onAccountChangeRef = useRef(onAccountChange);
+  activeViewRef.current = tab;
+  onAuthRequiredRef.current = onAuthRequired;
+  onAccountChangeRef.current = onAccountChange;
+
+  const abortLoads = useCallback(() => {
+    for (const controller of abortControllersRef.current) controller.abort();
+    abortControllersRef.current.clear();
+    activeLoadsRef.current = 0;
+    setLoading(false);
+    setDataStale(false);
+  }, []);
+
+  const clearData = useCallback(() => {
+    setIssues([]);
+    setPullRequests([]);
+    setRepos([]);
+    setOwners([]);
+    setFetchedAt("");
+    setError("");
+  }, []);
+
+  const resetData = useCallback(() => {
+    abortLoads();
+    invalidate();
+    clearData();
+    clearStatsCache();
+  }, [abortLoads, clearData]);
+
+  const loadData = useCallback((resources: Set<DashboardResource>, fresh = false) => {
+    if (!resources.size) return;
+    const controller = new AbortController();
+    abortControllersRef.current.add(controller);
+    setError("");
+
+    const cachedRepos = resources.has("repos") ? peek<ReposData>(CACHE_KEY.repos) : null;
+    if (cachedRepos) {
+      setRepos(cachedRepos.repos);
+      setOwners(cachedRepos.owners);
+      setFetchedAt(cachedRepos.fetchedAt);
+    }
+    const cachedIssues = resources.has("issues") ? peek<IssuesData>(CACHE_KEY.issues) : null;
+    if (cachedIssues) setIssues(cachedIssues.issues);
+    const cachedPrs = resources.has("prs") ? peek<PullRequestsData>(CACHE_KEY.prs) : null;
+    if (cachedPrs) setPullRequests(cachedPrs.pullRequests);
+
+    if (!cachedRepos && !cachedIssues && !cachedPrs) {
+      const persisted = readStatsCache();
+      if (persisted) {
+        setRepos(persisted.repos as GhRepo[]);
+        setOwners(persisted.owners);
+        setIssues(persisted.issues as GhIssue[]);
+        setPullRequests(persisted.pullRequests as GhPullRequest[]);
+        if (persisted.fetchedAt) setFetchedAt(persisted.fetchedAt);
+      }
+    }
+
+    const diagnostics = beginDashboardLoad(activeViewRef.current, resources, fresh);
+    let pending = resources.size;
+    activeLoadsRef.current += 1;
+    setLoading(true);
+    setDataStale(true);
+
+    const finish = (resource: DashboardResource, ok: boolean) => {
+      diagnostics.finishResource(resource, ok);
+      pending -= 1;
+      if (pending > 0 || !abortControllersRef.current.has(controller)) return;
+      abortControllersRef.current.delete(controller);
+      activeLoadsRef.current = Math.max(0, activeLoadsRef.current - 1);
+      if (activeLoadsRef.current === 0) {
+        setLoading(false);
+        setDataStale(false);
+      }
+    };
+    const handleFailure = (err: unknown) => {
+      if (controller.signal.aborted) return;
+      if (err instanceof AuthRequiredClientError) {
+        onAuthRequiredRef.current();
+        return;
+      }
+      if ((err as Error).name !== "AbortError") setError((err as Error).message);
+    };
+
+    if (resources.has("repos")) {
+      const result = swr<ReposData>(CACHE_KEY.repos, (signal) => fetchRepos(fresh, signal), {
+        fresh,
+        signal: controller.signal,
+      });
+      diagnostics.startResource("repos", result.source);
+      void result.promise.then((data) => {
+        if (!controller.signal.aborted) {
+          setRepos(data.repos);
+          setOwners(data.owners);
+          setFetchedAt(data.fetchedAt);
+        }
+        return true;
+      }, (err) => {
+        handleFailure(err);
+        return false;
+      }).then((ok) => finish("repos", ok));
+    }
+
+    if (resources.has("issues")) {
+      const result = swr<IssuesData>(CACHE_KEY.issues, (signal) => fetchIssues(fresh, signal), {
+        fresh,
+        signal: controller.signal,
+      });
+      diagnostics.startResource("issues", result.source);
+      void result.promise.then((data) => {
+        if (!controller.signal.aborted) setIssues(data.issues);
+        return true;
+      }, (err) => {
+        handleFailure(err);
+        return false;
+      }).then((ok) => finish("issues", ok));
+    }
+
+    if (resources.has("prs")) {
+      const result = swr<PullRequestsData>(CACHE_KEY.prs, (signal) => fetchPullRequests(fresh, signal), {
+        fresh,
+        signal: controller.signal,
+      });
+      diagnostics.startResource("prs", result.source);
+      void result.promise.then((data) => {
+        if (!controller.signal.aborted) setPullRequests(data.pullRequests);
+        return true;
+      }, (err) => {
+        handleFailure(err);
+        return false;
+      }).then((ok) => finish("prs", ok));
+    }
+  }, []);
+
+  const loadAll = useCallback((fresh = false) => loadData(allDashboardResources(), fresh), [loadData]);
+
+  useEffect(() => {
+    if (!authenticated) {
+      loadedAccountRef.current = null;
+      return;
+    }
+    if (accountsLoading) return;
+
+    const nextAccountKey = accountKey ?? "authenticated";
+    const accountChanged = loadedAccountRef.current !== null && loadedAccountRef.current !== nextAccountKey;
+    if (accountChanged) {
+      resetData();
+      onAccountChangeRef.current?.();
+    }
+    loadedAccountRef.current = nextAccountKey;
+    loadData(dataRequirementsForTab(tab, Boolean(routeRepoName), repositoryDetail), accountChanged);
+  }, [authenticated, accountsLoading, accountKey, tab, routeRepoName, repositoryDetail, loadData, resetData]);
+
+  useEffect(() => () => abortLoads(), [abortLoads]);
+
+  useEffect(() => {
+    if (repos.length === 0 && issues.length === 0 && pullRequests.length === 0) return;
+    writeStatsCache({ repos, owners, issues, pullRequests, fetchedAt });
+  }, [repos, owners, issues, pullRequests, fetchedAt]);
+
+  return {
+    issues,
+    pullRequests,
+    repos,
+    owners,
+    fetchedAt,
+    loading,
+    dataStale,
+    error,
+    loadData,
+    loadAll,
+    resetData,
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,6 +48,7 @@ import {
 import { fetchRepoSecuritySummary } from "./server/securityAlerts";
 import { handleRepoInsights } from "./server/repoInsights";
 import { getCIHealthCached, invalidateCIHealthCache } from "./server/ciHealth";
+import { getProviderMetrics } from "./server/providerDiagnostics";
 
 const STARGAZERS_QUERY = `
 query($owner:String!, $name:String!, $cursor:String, $direction:OrderDirection!) {
@@ -1259,6 +1260,7 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
   if (url.startsWith("/api/accounts/activate")) return handleAccountActivate(req, res);
   if (url.startsWith("/api/accounts/add-token")) return handleAccountAddToken(req, res);
   if (url.startsWith("/api/provider-configs")) return handleProviderConfigsList(res);
+  if (url.startsWith("/api/diagnostics/provider-metrics")) return sendJson(res, 200, getProviderMetrics());
   if (url.startsWith("/api/accounts")) {
     if (req.method === "DELETE") {
       return handleAccountRemove(req, res, new URL(url, "http://localhost"));

--- a/src/server/dashboardData.ts
+++ b/src/server/dashboardData.ts
@@ -4,6 +4,7 @@ import { AuthRequiredError } from "./githubClient";
 import { getProviderForAccount } from "./providers/registry";
 import type { Account, OwnersOutcome, Provider } from "./providers/types";
 import { attachHistory, recordSnapshots } from "./snapshots";
+import { measureProviderCall } from "./providerDiagnostics";
 
 export type ReposResult =
   | { ok: true; repos: GhRepo[]; owners: string[]; fetchedAt: string }
@@ -66,7 +67,7 @@ async function resolveActive(): Promise<{ account: Account; provider: Provider }
 const ownersStore = memoize<OwnersOutcome>(TTL_MS, async (): Promise<OwnersOutcome> => {
   const active = await resolveActive();
   if (!active) return authFail();
-  return active.provider.listOwners(active.account);
+  return measureProviderCall("owners", () => active.provider.listOwners(active.account));
 });
 
 const reposStore = memoize<ReposResult>(TTL_MS, async (): Promise<ReposResult> => {
@@ -75,7 +76,7 @@ const reposStore = memoize<ReposResult>(TTL_MS, async (): Promise<ReposResult> =
   try {
     const active = await resolveActive();
     if (!active) return authFail();
-    const repos = await active.provider.listRepos(active.account, ownersResult.owners);
+    const repos = await measureProviderCall("repos", () => active.provider.listRepos(active.account, ownersResult.owners));
     try {
       await recordSnapshots(repos);
       await attachHistory(repos);
@@ -95,7 +96,7 @@ const issuesStore = memoize<IssuesResult>(TTL_MS, async (): Promise<IssuesResult
   try {
     const active = await resolveActive();
     if (!active) return authFail();
-    const issues = await active.provider.listIssues(active.account, ownersResult.owners);
+    const issues = await measureProviderCall("issues", () => active.provider.listIssues(active.account, ownersResult.owners));
     return { ok: true, issues, owners: ownersResult.owners, fetchedAt: new Date().toISOString() };
   } catch (error: unknown) {
     if (error instanceof AuthRequiredError) return authFail();
@@ -109,7 +110,7 @@ const pullRequestsStore = memoize<PullRequestsResult>(TTL_MS, async (): Promise<
   try {
     const active = await resolveActive();
     if (!active) return authFail();
-    const pullRequests = await active.provider.listPullRequests(active.account, ownersResult.owners);
+    const pullRequests = await measureProviderCall("pullRequests", () => active.provider.listPullRequests(active.account, ownersResult.owners));
     return { ok: true, pullRequests, owners: ownersResult.owners, fetchedAt: new Date().toISOString() };
   } catch (error: unknown) {
     if (error instanceof AuthRequiredError) return authFail();

--- a/src/server/providerDiagnostics.ts
+++ b/src/server/providerDiagnostics.ts
@@ -1,0 +1,65 @@
+export interface ProviderOperationMetric {
+  operation: string;
+  calls: number;
+  failures: number;
+  totalDurationMs: number;
+  averageDurationMs: number;
+  lastDurationMs: number;
+  lastCalledAt: string;
+}
+
+interface MutableMetric {
+  calls: number;
+  failures: number;
+  totalDurationMs: number;
+  lastDurationMs: number;
+  lastCalledAt: string;
+}
+
+const startedAt = new Date().toISOString();
+const operations = new Map<string, MutableMetric>();
+
+export async function measureProviderCall<T>(operation: string, call: () => Promise<T>): Promise<T> {
+  const started = performance.now();
+  let failed = false;
+  try {
+    return await call();
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    const duration = Math.round((performance.now() - started) * 10) / 10;
+    const metric = operations.get(operation) ?? {
+      calls: 0,
+      failures: 0,
+      totalDurationMs: 0,
+      lastDurationMs: 0,
+      lastCalledAt: "",
+    };
+    metric.calls += 1;
+    metric.failures += failed ? 1 : 0;
+    metric.totalDurationMs = Math.round((metric.totalDurationMs + duration) * 10) / 10;
+    metric.lastDurationMs = duration;
+    metric.lastCalledAt = new Date().toISOString();
+    operations.set(operation, metric);
+    if (process.env.GITDECK_DIAGNOSTICS === "1") {
+      console.info(`[gitdeck:provider] ${operation} ${duration}ms ${failed ? "failed" : "ok"}`);
+    }
+  }
+}
+
+export function getProviderMetrics(): { ok: true; startedAt: string; operations: ProviderOperationMetric[] } {
+  return {
+    ok: true,
+    startedAt,
+    operations: [...operations.entries()].map(([operation, metric]) => ({
+      operation,
+      ...metric,
+      averageDurationMs: metric.calls ? Math.round((metric.totalDurationMs / metric.calls) * 10) / 10 : 0,
+    })).sort((a, b) => a.operation.localeCompare(b.operation)),
+  };
+}
+
+export function resetProviderMetrics(): void {
+  operations.clear();
+}

--- a/src/styles/inbox.css
+++ b/src/styles/inbox.css
@@ -12,41 +12,96 @@
   }
 
   /* Sidebar mailbox list (rendered inside SidebarControls when tab=inbox) */
+  .sidebar.inbox-sidebar {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 0;
+  }
+  .inbox-side-head {
+    flex: 0 0 auto;
+    min-height: 48px;
+    padding: 12px 14px 8px;
+  }
+  .mailbox-total {
+    min-width: 34px;
+    padding: 2px 8px;
+    border: 1px solid var(--border-soft);
+    border-radius: 999px;
+    background: var(--panel-2);
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.35;
+    text-align: center;
+  }
+  .inbox-sidebar .search-wrap {
+    flex: 0 0 auto;
+    padding: 4px 12px 10px;
+  }
+  .inbox-sidebar .search-input {
+    min-height: 40px;
+    padding-inline: 11px;
+  }
   .mailbox-list {
     display: grid;
-    gap: 2px;
-    padding: 0 8px;
+    align-content: start;
+    gap: 3px;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 1px 10px 10px;
+    scrollbar-gutter: stable;
   }
   .mailbox-item {
-    display: flex; align-items: center; justify-content: space-between; gap: 10px;
-    width: 100%; min-height: 32px;
-    border: 0; border-radius: 7px;
+    display: flex; align-items: center; justify-content: space-between; gap: 12px;
+    width: 100%; min-height: 36px;
+    border: 1px solid transparent; border-radius: 8px;
     background: transparent; color: var(--muted);
-    cursor: pointer; padding: 6px 9px; text-align: left;
+    cursor: pointer; padding: 7px 9px; text-align: left;
+    transition: background-color .15s ease, border-color .15s ease, color .15s ease;
   }
-  .mailbox-item:hover { background: var(--hover-surface); color: var(--text); }
+  .mailbox-item:hover {
+    border-color: var(--border-soft);
+    background: var(--hover-surface);
+    color: var(--text);
+  }
+  .mailbox-item:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: var(--ring);
+  }
   .mailbox-item.active {
+    border-color: color-mix(in srgb, var(--accent) 22%, transparent);
     background: var(--accent-faint); color: var(--text);
-    box-shadow: inset 2px 0 0 var(--accent);
+    box-shadow: inset 3px 0 0 var(--accent);
   }
   .mailbox-item span {
+    flex: 1;
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
     font-size: 13px; font-weight: 600;
   }
+  .mailbox-item.active span { font-weight: 700; }
   .mailbox-item strong {
-    min-width: 26px; padding: 1px 7px; border-radius: 999px;
+    flex: 0 0 auto;
+    min-width: 28px; padding: 2px 7px; border-radius: 999px;
     background: var(--panel-2); color: var(--muted);
-    font-size: 11px; font-variant-numeric: tabular-nums; text-align: center;
+    font-size: 11px; font-weight: 700; font-variant-numeric: tabular-nums;
+    line-height: 1.2; text-align: center;
   }
+  .mailbox-item.empty strong { color: var(--muted-2); font-weight: 600; }
   .mailbox-item.active strong { background: var(--accent-soft); color: var(--accent); }
   .mailbox-action {
-    margin: 14px 12px 8px;
-    border: 1px solid var(--border-soft); border-radius: 7px;
-    background: var(--panel); color: var(--text);
-    cursor: pointer; padding: 8px 10px;
+    flex: 0 0 auto;
+    margin: 8px 12px 12px;
+    border: 1px solid var(--border-soft); border-radius: 8px;
+    background: var(--panel-2); color: var(--text);
+    cursor: pointer; padding: 9px 10px;
     font-size: 12.5px; font-weight: 600;
+    transition: border-color .15s ease, background-color .15s ease, color .15s ease;
   }
-  .mailbox-action:hover { border-color: var(--accent); color: var(--accent); }
+  .mailbox-action:hover { border-color: var(--accent); background: var(--accent-faint); color: var(--accent); }
+  .mailbox-action:focus-visible { outline: none; border-color: var(--accent); box-shadow: var(--ring); }
 
   .inbox-list-pagination {
     border-top: 1px solid var(--border-soft);

--- a/src/utils/loadDiagnostics.ts
+++ b/src/utils/loadDiagnostics.ts
@@ -1,0 +1,81 @@
+import type { SwrSource } from "../api/cache";
+import type { DashboardResource, DashboardTab } from "./dataRequirements";
+
+export interface DashboardLoadMetric {
+  id: number;
+  tab: DashboardTab;
+  resources: DashboardResource[];
+  fresh: boolean;
+  startedAt: string;
+  firstContentMs: number | null;
+  totalMs: number;
+  networkRequests: number;
+  cacheHits: number;
+  deduplicatedRequests: number;
+  failures: number;
+}
+
+const MAX_METRICS = 50;
+const metrics: DashboardLoadMetric[] = [];
+let nextId = 1;
+
+function now(): number {
+  return typeof performance === "undefined" ? Date.now() : performance.now();
+}
+
+export function beginDashboardLoad(tab: DashboardTab, resources: Set<DashboardResource>, fresh: boolean) {
+  const id = nextId++;
+  const started = now();
+  const startedAt = new Date().toISOString();
+  let firstContentMs: number | null = null;
+  let networkRequests = 0;
+  let cacheHits = 0;
+  let deduplicatedRequests = 0;
+  let failures = 0;
+  let completed = 0;
+
+  return {
+    startResource(_resource: DashboardResource, source: SwrSource) {
+      if (source === "network") networkRequests += 1;
+      else if (source === "cache") cacheHits += 1;
+      else deduplicatedRequests += 1;
+    },
+    finishResource(_resource: DashboardResource, ok: boolean) {
+      const elapsed = Math.round((now() - started) * 10) / 10;
+      if (firstContentMs === null && ok) firstContentMs = elapsed;
+      if (!ok) failures += 1;
+      completed += 1;
+      if (completed !== resources.size) return;
+      const metric: DashboardLoadMetric = {
+        id,
+        tab,
+        resources: [...resources],
+        fresh,
+        startedAt,
+        firstContentMs,
+        totalMs: elapsed,
+        networkRequests,
+        cacheHits,
+        deduplicatedRequests,
+        failures,
+      };
+      metrics.push(metric);
+      if (metrics.length > MAX_METRICS) metrics.splice(0, metrics.length - MAX_METRICS);
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("gitdeck:dashboard-load", { detail: metric }));
+        if (localStorage.getItem("gh-dash.diagnostics") === "1") {
+          console.info("[gitdeck:load]", metric);
+        }
+      }
+    },
+  };
+}
+
+export function getDashboardLoadMetrics(): DashboardLoadMetric[] {
+  return metrics.map((metric) => ({ ...metric, resources: [...metric.resources] }));
+}
+
+export function clearDashboardLoadMetrics(): void {
+  metrics.length = 0;
+  nextId = 1;
+}

--- a/tests/hooks/useDashboardData.test.ts
+++ b/tests/hooks/useDashboardData.test.ts
@@ -1,0 +1,134 @@
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { invalidate } from "../../src/api/cache";
+import { useDashboardData, type DashboardDataState } from "../../src/hooks/useDashboardData";
+import type { DashboardTab } from "../../src/utils/dataRequirements";
+
+const api = vi.hoisted(() => ({
+  fetchRepos: vi.fn(),
+  fetchIssues: vi.fn(),
+  fetchPullRequests: vi.fn(),
+}));
+
+vi.mock("../../src/api/github", () => ({
+  AuthRequiredClientError: class AuthRequiredClientError extends Error {},
+  fetchRepos: api.fetchRepos,
+  fetchIssues: api.fetchIssues,
+  fetchPullRequests: api.fetchPullRequests,
+}));
+
+interface HarnessProps {
+  tab: DashboardTab;
+  accountKey?: string;
+  routeRepoName?: string;
+  repositoryDetail?: string;
+}
+
+let latest: DashboardDataState;
+let root: Root;
+let container: HTMLDivElement;
+
+function Harness(props: HarnessProps) {
+  latest = useDashboardData({
+    authenticated: true,
+    accountsLoading: false,
+    accountKey: props.accountKey ?? "account-a",
+    tab: props.tab,
+    routeRepoName: props.routeRepoName ?? "",
+    repositoryDetail: props.repositoryDetail,
+    onAuthRequired: vi.fn(),
+  });
+  return null;
+}
+
+const reposResult = (name: string) => ({
+  ok: true as const,
+  repos: [{ nameWithOwner: name }],
+  owners: [name.split("/")[0]],
+  fetchedAt: "2026-01-01T00:00:00.000Z",
+});
+const issuesResult = { ok: true as const, issues: [], owners: [], fetchedAt: "2026-01-01T00:00:00.000Z" };
+const prsResult = { ok: true as const, pullRequests: [], owners: [], fetchedAt: "2026-01-01T00:00:00.000Z" };
+
+async function render(props: HarnessProps) {
+  await act(async () => {
+    root.render(createElement(Harness, props));
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  invalidate();
+  localStorage.clear();
+  api.fetchRepos.mockReset().mockResolvedValue(reposResult("owner/repo"));
+  api.fetchIssues.mockReset().mockResolvedValue(issuesResult);
+  api.fetchPullRequests.mockReset().mockResolvedValue(prsResult);
+  container = document.createElement("div");
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  invalidate();
+});
+
+describe("useDashboardData lazy loading", () => {
+  it("loads only resources required by the active tab", async () => {
+    await render({ tab: "repos" });
+    expect(api.fetchRepos).toHaveBeenCalledTimes(1);
+    expect(api.fetchIssues).not.toHaveBeenCalled();
+    expect(api.fetchPullRequests).not.toHaveBeenCalled();
+
+    await render({ tab: "issues" });
+    expect(api.fetchIssues).toHaveBeenCalledTimes(1);
+    expect(api.fetchPullRequests).not.toHaveBeenCalled();
+  });
+
+  it("loads the resource required by a deep-linked repository section", async () => {
+    await render({ tab: "repos", routeRepoName: "owner/repo", repositoryDetail: "pull-requests" });
+    expect(api.fetchRepos).toHaveBeenCalledTimes(1);
+    expect(api.fetchPullRequests).toHaveBeenCalledTimes(1);
+    expect(api.fetchIssues).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates an in-flight resource while switching tabs", async () => {
+    let resolveRepos!: (value: ReturnType<typeof reposResult>) => void;
+    api.fetchRepos.mockImplementationOnce(() => new Promise((resolve) => { resolveRepos = resolve; }));
+
+    await render({ tab: "repos" });
+    await render({ tab: "issues" });
+    expect(api.fetchRepos).toHaveBeenCalledTimes(1);
+    expect(api.fetchIssues).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolveRepos(reposResult("owner/repo")));
+  });
+
+  it("aborts stale requests and ignores their result after an account switch", async () => {
+    let oldSignal: AbortSignal | undefined;
+    let resolveOld!: (value: ReturnType<typeof reposResult>) => void;
+    api.fetchRepos
+      .mockImplementationOnce((_fresh: boolean, signal?: AbortSignal) => {
+        oldSignal = signal;
+        return new Promise((resolve) => { resolveOld = resolve; });
+      })
+      .mockResolvedValueOnce(reposResult("new/repo"));
+
+    await render({ tab: "repos", accountKey: "account-a" });
+    await render({ tab: "repos", accountKey: "account-b" });
+    expect(oldSignal?.aborted).toBe(true);
+    expect(latest.repos[0]?.nameWithOwner).toBe("new/repo");
+
+    await act(async () => resolveOld(reposResult("old/repo")));
+    expect(latest.repos[0]?.nameWithOwner).toBe("new/repo");
+  });
+
+  it("supports an explicit fresh refresh of the current resources", async () => {
+    await render({ tab: "prs" });
+    expect(api.fetchPullRequests).toHaveBeenCalledWith(false, expect.any(AbortSignal));
+
+    await act(async () => latest.loadData(new Set(["repos", "prs"]), true));
+    expect(api.fetchRepos).toHaveBeenLastCalledWith(true, expect.any(AbortSignal));
+    expect(api.fetchPullRequests).toHaveBeenLastCalledWith(true, expect.any(AbortSignal));
+  });
+});

--- a/tests/server/providerDiagnostics.test.ts
+++ b/tests/server/providerDiagnostics.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getProviderMetrics, measureProviderCall, resetProviderMetrics } from "../../src/server/providerDiagnostics";
+
+describe("provider diagnostics", () => {
+  beforeEach(() => resetProviderMetrics());
+
+  it("counts provider calls, failures and durations", async () => {
+    await measureProviderCall("repos", async () => ["repo"]);
+    await expect(measureProviderCall("repos", async () => { throw new Error("failed"); })).rejects.toThrow("failed");
+
+    expect(getProviderMetrics().operations).toEqual([
+      expect.objectContaining({
+        operation: "repos",
+        calls: 2,
+        failures: 1,
+      }),
+    ]);
+    expect(getProviderMetrics().operations[0].totalDurationMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tests/utils/loadDiagnostics.test.ts
+++ b/tests/utils/loadDiagnostics.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { beginDashboardLoad, clearDashboardLoadMetrics, getDashboardLoadMetrics } from "../../src/utils/loadDiagnostics";
+
+describe("dashboard load diagnostics", () => {
+  beforeEach(() => clearDashboardLoadMetrics());
+
+  it("records request sources and time to first content", () => {
+    const load = beginDashboardLoad("issues", new Set(["repos", "issues"]), false);
+    load.startResource("repos", "cache");
+    load.startResource("issues", "network");
+    load.finishResource("repos", true);
+    load.finishResource("issues", true);
+
+    expect(getDashboardLoadMetrics()).toEqual([
+      expect.objectContaining({
+        tab: "issues",
+        resources: ["repos", "issues"],
+        networkRequests: 1,
+        cacheHits: 1,
+        deduplicatedRequests: 0,
+        failures: 0,
+      }),
+    ]);
+    expect(getDashboardLoadMetrics()[0].firstContentMs).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- extract base dashboard loading, cancellation, cache persistence, and account switching into `useDashboardData`
- add integration coverage for lazy tab resources, deep links, request deduplication, refreshes, and account-switch races
- record browser load timing/cache metrics and provider-side call counts and durations
- expose provider metrics at `GET /api/diagnostics/provider-metrics` and document optional diagnostics logging
- polish the Inbox mailbox sidebar and show the loaded Board count in its tab badge

## Validation
- `npm test` — 94 tests passed
- `npm run build` — passed (existing bundle-size warning remains)

## Notes
- `npm run typecheck` still reports the pre-existing errors in IssueList, PullRequestList, TriageWorkspace, openaiDigest, and colors.test.
