### PR TITLE
fix: keep sidebar filter options stable

### DIFF
--- a/src/components/SidebarControls.tsx
+++ b/src/components/SidebarControls.tsx
@@ -78,14 +78,14 @@ function CheckList({
   userLogin?: string;
 }) {
   const { t } = useI18n();
-  // Original sort (checked first, then by count, then alphabetical) with one addition:
-  // when userLogin is set, the user's personal account always sorts last (orgs first).
+  // Keep filter options in a stable order as selections change. When userLogin
+  // is set, the user's personal account still sorts last (orgs first).
   const sorted = [...entries].sort((a, b) => {
     if (userLogin) {
       if (a[0] === userLogin && b[0] !== userLogin) return 1;
       if (b[0] === userLogin && a[0] !== userLogin) return -1;
     }
-    return Number(selected.has(b[0])) - Number(selected.has(a[0])) || countOf(b[1]) - countOf(a[1]) || a[0].localeCompare(b[0]);
+    return countOf(b[1]) - countOf(a[1]) || a[0].localeCompare(b[0]);
   });
   if (!sorted.length) return <div style={{ padding: 8, color: "var(--muted-2)", fontSize: 12 }}>{t("common.noMatches")}</div>;
 


### PR DESCRIPTION
## Summary
- keep sidebar checklist options in count/alphabetical order when selections change
- preserve the existing behavior that places the personal account after organizations
- prevent checked options from unexpectedly jumping to the top

## Verification
- `npm test` (108 tests passed)
- `npm run build`
- `npm run typecheck` currently reports pre-existing errors on `main` unrelated to this change