### PR TITLE
fix: report HTML upstream errors instead of a JSON SyntaxError

### DIFF
--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -1,3 +1,4 @@
+import { interpretUpstreamJson } from "../utils/upstreamResponse";
 import { getEtag, peek, setEtag, swr } from "./cache";
 import type {
   ApiError,
@@ -40,7 +41,16 @@ async function readJson<T>(url: string, init?: RequestInit, cacheKey?: string): 
     const cached = peek<T>(cacheKey);
     if (cached) return cached;
   }
-  const json = (await response.json()) as T | (ApiError & { needsAuth?: boolean });
+  const body = interpretUpstreamJson<T | (ApiError & { needsAuth?: boolean })>("Gitdeck server", {
+    status: response.status,
+    statusText: response.statusText,
+    contentType: response.headers.get("content-type"),
+    text: await response.text(),
+  });
+  // A JSON error body (4xx/5xx from our API) is still parsed so `needsAuth`
+  // and `error` reach the caller; anything else becomes a readable message.
+  const json = body.ok ? body.data : parseJsonOrNull<T | ApiError>(body.error);
+  if (json === null) throw new Error(body.ok ? "Empty response" : body.error);
   const maybeError = json as Partial<ApiError> & { needsAuth?: boolean };
   if (response.status === 401 || maybeError.needsAuth) {
     throw new AuthRequiredClientError(maybeError.error || "authentication required");
@@ -53,6 +63,14 @@ async function readJson<T>(url: string, init?: RequestInit, cacheKey?: string): 
     if (newEtag) setEtag(cacheKey, newEtag);
   }
   return json as T;
+}
+
+function parseJsonOrNull<T>(text: string): T | null {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
 }
 
 function withSignal(signal?: AbortSignal): RequestInit | undefined {

--- a/src/server/githubClient.ts
+++ b/src/server/githubClient.ts
@@ -1,8 +1,10 @@
 import { getActiveToken } from "./authProvider";
+import { readUpstreamJson, requireUpstreamJson } from "./upstream";
 
 const API_ROOT = "https://api.github.com";
 const GRAPHQL_URL = `${API_ROOT}/graphql`;
 const USER_AGENT = "gitdeck";
+const SERVICE = "GitHub";
 
 export class AuthRequiredError extends Error {
   constructor(message = "authentication required") {
@@ -44,9 +46,9 @@ export async function gql<T>(query: string, variables: Record<string, unknown>):
     body: JSON.stringify({ query, variables }),
   });
   if (response.status === 401) throw new AuthRequiredError();
-  const json = (await response.json()) as { data?: T; errors?: { message: string }[] };
-  if (json.errors?.length) throw new Error(json.errors.map((error) => error.message).join("; "));
-  if (!json.data) throw new Error("Empty GraphQL response");
+  const json = await requireUpstreamJson<{ data?: T; errors?: { message: string }[] } | null>(SERVICE, response);
+  if (json?.errors?.length) throw new Error(json.errors.map((error) => error.message).join("; "));
+  if (!json?.data) throw new Error("Empty GraphQL response");
   return json.data;
 }
 
@@ -71,15 +73,8 @@ export async function restApi<T = unknown>(path: string): Promise<RestResult<T>>
   }
   const response = await fetch(buildUrl(path), { headers: authHeaders(token) });
   if (response.status === 204) return { ok: true, data: null as T };
-  const text = await response.text();
-  if (!response.ok) {
-    return { ok: false, error: text || `HTTP ${response.status}`, status: response.status };
-  }
-  try {
-    return { ok: true, data: JSON.parse(text) as T };
-  } catch {
-    return { ok: false, error: "invalid JSON", status: response.status };
-  }
+  const result = await readUpstreamJson<T>(SERVICE, response);
+  return result.ok ? { ok: true, data: result.data } : { ok: false, error: result.error, status: result.status };
 }
 
 function parseNextLink(header: string | null): string | null {
@@ -105,17 +100,12 @@ export async function restApiPaginate<T = unknown>(path: string): Promise<RestRe
   let nextUrl: string | null = buildUrl(path);
   while (nextUrl) {
     const response: Response = await fetch(nextUrl, { headers: authHeaders(token) });
-    const text = await response.text();
-    if (!response.ok) {
-      return { ok: false, error: text || `HTTP ${response.status}`, status: response.status };
-    }
-    let page: unknown;
-    try {
-      page = JSON.parse(text);
-    } catch {
-      return { ok: false, error: "invalid JSON", status: response.status };
-    }
-    if (Array.isArray(page)) {
+    const result = await readUpstreamJson<unknown>(SERVICE, response);
+    if (!result.ok) return { ok: false, error: result.error, status: result.status };
+    const page = result.data;
+    if (page == null) {
+      // Nothing to collect on this page.
+    } else if (Array.isArray(page)) {
       for (const item of page) all.push(item as T);
     } else {
       // Some endpoints (e.g. search) return wrapped results; pagination there

--- a/src/server/providers/forgejo.ts
+++ b/src/server/providers/forgejo.ts
@@ -3,6 +3,7 @@ import type {
   GhPullRequest,
   GhRepo,
 } from "../../types/github";
+import { readUpstreamJson } from "../upstream";
 import {
   fetchForgejoIssues,
   fetchForgejoNotifications,
@@ -60,16 +61,14 @@ export class ForgejoProvider implements Provider {
         Authorization: `token ${token}`,
       },
     });
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(`Identity lookup failed: ${text || `HTTP ${response.status}`}`);
-    }
-    const data = (await response.json()) as {
+    const identity = await readUpstreamJson<{
       login?: string;
       username?: string;
       avatar_url?: string;
       html_url?: string;
-    };
+    } | null>(this.config.label, response);
+    if (!identity.ok) throw new Error(`Identity lookup failed: ${identity.error}`);
+    const data = identity.data ?? {};
     const login = data.login ?? data.username ?? "";
     if (!login) throw new Error("Forgejo /user response missing login");
     return {

--- a/src/server/providers/forgejoData.ts
+++ b/src/server/providers/forgejoData.ts
@@ -7,6 +7,7 @@ import type {
   ReviewDecision,
 } from "../../types/github";
 import { getProviderConfig } from "../accountStore";
+import { readUpstreamJson } from "../upstream";
 import type { Account, ProviderConfig } from "./types";
 
 interface ForgejoUser {
@@ -379,14 +380,11 @@ export async function fetchForgejoNotifications(account: Account, ifModifiedSinc
   if (response.status === 304) {
     return { refreshed: false, notifications: [], pollInterval: 60, lastModified };
   }
-  if (!response.ok) {
-    const text = await response.text();
-    return { error: text || `HTTP ${response.status}` };
-  }
-  const raw = (await response.json()) as ForgejoNotification[];
+  const page = await readUpstreamJson<ForgejoNotification[] | null>(config.label, response);
+  if (!page.ok) return { error: page.error };
   return {
     refreshed: true,
-    notifications: raw.map(normalizeNotification),
+    notifications: (page.data ?? []).map(normalizeNotification),
     pollInterval: 60,
     lastModified,
   };

--- a/src/server/providers/github.ts
+++ b/src/server/providers/github.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { readUpstreamJson, requireUpstreamJson } from "../upstream";
 import type {
   GhIssue,
   GhLabel,
@@ -22,6 +23,14 @@ import type {
   ProviderConfig,
   ProviderIdentity,
 } from "./types";
+
+interface TokenExchangeResponse {
+  access_token?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+  interval?: number;
+}
 
 const execFileAsync = promisify(execFile);
 
@@ -143,13 +152,16 @@ export class GitHubProvider implements Provider {
       },
       body,
     });
-    const data = (await response.json()) as {
-      access_token?: string;
-      scope?: string;
-      error?: string;
-      error_description?: string;
-      interval?: number;
-    };
+    const exchange = await readUpstreamJson<TokenExchangeResponse | null>(this.config.label, response);
+    let data: TokenExchangeResponse = {};
+    if (exchange.ok) {
+      data = exchange.data ?? {};
+    } else {
+      // Device-flow states such as authorization_pending arrive as a 4xx with a
+      // JSON body, which readUpstreamJson keeps verbatim in `error`.
+      try { data = JSON.parse(exchange.error) as TokenExchangeResponse; }
+      catch { return { status: "error", error: exchange.error }; }
+    }
 
     if (data.access_token) {
       const identity = await this.fetchIdentity(data.access_token);
@@ -187,10 +199,11 @@ export class GitHubProvider implements Provider {
         Authorization: `Bearer ${token}`,
       },
     });
-    if (!response.ok) {
+    const identity = await readUpstreamJson<{ login?: string; avatar_url?: string; html_url?: string } | null>(this.config.label, response);
+    if (!identity.ok) {
       return { login: "", scope: response.headers.get("x-oauth-scopes") };
     }
-    const data = (await response.json()) as { login?: string; avatar_url?: string; html_url?: string };
+    const data = identity.data ?? {};
     return {
       login: data.login ?? "",
       scope: response.headers.get("x-oauth-scopes"),
@@ -249,9 +262,9 @@ export class GitHubProvider implements Provider {
       body: JSON.stringify({ query, variables }),
     });
     if (response.status === 401) throw new GitHubAuthRequiredError();
-    const json = (await response.json()) as { data?: T; errors?: { message: string }[] };
-    if (json.errors?.length) throw new Error(json.errors.map((entry) => entry.message).join("; "));
-    if (!json.data) throw new Error("Empty GraphQL response");
+    const json = await requireUpstreamJson<{ data?: T; errors?: { message: string }[] } | null>(this.config.label, response);
+    if (json?.errors?.length) throw new Error(json.errors.map((entry) => entry.message).join("; "));
+    if (!json?.data) throw new Error("Empty GraphQL response");
     return json.data;
   }
 
@@ -422,12 +435,9 @@ export class GitHubProvider implements Provider {
           return { ok: true, refreshed: false, notifications: [], lastModified: firstLastModified, pollInterval: firstPollInterval };
         }
       }
-      if (!response.ok) {
-        const text = await response.text();
-        return { ok: false, error: text || `HTTP ${response.status}` };
-      }
-      const raw = (await response.json()) as RawGitHubNotification[];
-      for (const entry of raw) collected.push(normalizeGitHubNotification(entry));
+      const page = await readUpstreamJson<RawGitHubNotification[] | null>(this.config.label, response);
+      if (!page.ok) return { ok: false, error: page.error };
+      for (const entry of page.data ?? []) collected.push(normalizeGitHubNotification(entry));
       const link = response.headers.get("link");
       url = parseNextLink(link);
       pages += 1;

--- a/src/server/providers/gitlab.ts
+++ b/src/server/providers/gitlab.ts
@@ -1,5 +1,6 @@
 import type { GhIssue, GhPullRequest, GhRepo } from "../../types/github";
 import { refreshGitLabTokenIfNeeded } from "../gitlabTokenRefresh";
+import { readUpstreamJson } from "../upstream";
 import {
   fetchGitLabIssues,
   fetchGitLabMergeRequests,
@@ -55,9 +56,9 @@ export class GitLabProvider implements Provider {
         "PRIVATE-TOKEN": token,
       },
     });
-    const text = await response.text();
-    if (!response.ok) throw new Error(`Identity lookup failed: ${text || `HTTP ${response.status}`}`);
-    const data = JSON.parse(text) as { username?: string; avatar_url?: string; web_url?: string };
+    const identity = await readUpstreamJson<{ username?: string; avatar_url?: string; web_url?: string } | null>(this.config.label, response);
+    if (!identity.ok) throw new Error(`Identity lookup failed: ${identity.error}`);
+    const data = identity.data ?? {};
     if (!data.username) throw new Error("GitLab /user response missing username");
     return {
       login: data.username,

--- a/src/server/providers/gitlabData.ts
+++ b/src/server/providers/gitlabData.ts
@@ -6,6 +6,7 @@ import type {
   GhRepo,
   GhUser,
 } from "../../types/github";
+import { readUpstreamJson } from "../upstream";
 import type { Account, ProviderConfig } from "./types";
 
 interface GitLabUser {
@@ -91,14 +92,7 @@ async function rest<T>(account: Account, config: ProviderConfig, path: string, i
     ...init,
     headers: { ...headers(account, config), ...((init?.headers as Record<string, string>) ?? {}) },
   });
-  const text = await response.text();
-  if (!response.ok) return { ok: false, status: response.status, error: text || `HTTP ${response.status}` };
-  if (!text) return { ok: true, status: response.status, data: null as T };
-  try {
-    return { ok: true, status: response.status, data: JSON.parse(text) as T };
-  } catch {
-    return { ok: false, status: response.status, error: "invalid JSON" };
-  }
+  return readUpstreamJson<T>(config.label, response);
 }
 
 async function paginate<T>(account: Account, config: ProviderConfig, path: string, maxPages = 10): Promise<RestResult<T[]>> {

--- a/src/server/upstream.ts
+++ b/src/server/upstream.ts
@@ -1,0 +1,19 @@
+import { interpretUpstreamJson, type UpstreamJson } from "../utils/upstreamResponse";
+
+/** Reads a fetch `Response` as JSON, mapping HTML/non-JSON bodies to a readable error. */
+export async function readUpstreamJson<T>(service: string, response: Response): Promise<UpstreamJson<T>> {
+  const text = await response.text();
+  return interpretUpstreamJson<T>(service, {
+    status: response.status,
+    statusText: response.statusText,
+    contentType: response.headers.get("content-type"),
+    text,
+  });
+}
+
+/** Like {@link readUpstreamJson} but throws on any failure. */
+export async function requireUpstreamJson<T>(service: string, response: Response): Promise<T> {
+  const result = await readUpstreamJson<T>(service, response);
+  if (!result.ok) throw new Error(result.error);
+  return result.data;
+}

--- a/src/utils/upstreamResponse.ts
+++ b/src/utils/upstreamResponse.ts
@@ -1,0 +1,56 @@
+export interface UpstreamResponse {
+  status: number;
+  statusText?: string;
+  contentType?: string | null;
+  text: string;
+}
+
+export type UpstreamJson<T> =
+  | { ok: true; status: number; data: T }
+  | { ok: false; status: number; error: string };
+
+export function looksLikeHtml(text: string, contentType?: string | null): boolean {
+  if (contentType && /text\/html/i.test(contentType)) return true;
+  return /^\s*(<!doctype\s+html|<html[\s>])/i.test(text);
+}
+
+function tryParseJson(text: string): { parsed: true; value: unknown } | { parsed: false } {
+  try {
+    return { parsed: true, value: JSON.parse(text) };
+  } catch {
+    return { parsed: false };
+  }
+}
+
+function describeStatus(response: UpstreamResponse): string {
+  const statusText = response.statusText?.trim();
+  return statusText ? `HTTP ${response.status} ${statusText}` : `HTTP ${response.status}`;
+}
+
+/**
+ * Turns an upstream response body into JSON or a readable error.
+ *
+ * Gateways and edge servers answer outages with HTML pages instead of the JSON
+ * an API normally returns; blindly calling `response.json()` on those surfaces
+ * a `SyntaxError` ("Unexpected token '<' ...") to the user. Here a non-JSON
+ * body is reported as "<service> returned HTTP 502 Bad Gateway" instead, while
+ * JSON error bodies are passed through untouched so callers can still inspect
+ * them.
+ */
+export function interpretUpstreamJson<T>(service: string, response: UpstreamResponse): UpstreamJson<T> {
+  const { status, text } = response;
+  const ok = status >= 200 && status < 300;
+  const trimmed = text.trim();
+
+  if (ok && !trimmed) return { ok: true, status, data: null as T };
+
+  const json = trimmed ? tryParseJson(trimmed) : ({ parsed: false } as const);
+  if (json.parsed) {
+    return ok
+      ? { ok: true, status, data: json.value as T }
+      : { ok: false, status, error: trimmed };
+  }
+
+  const kind = looksLikeHtml(trimmed, response.contentType) ? "an HTML page" : "a non-JSON response";
+  return { ok: false, status, error: `${service} returned ${describeStatus(response)} with ${kind} instead of JSON` };
+}

--- a/tests/utils/upstreamResponse.test.ts
+++ b/tests/utils/upstreamResponse.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { interpretUpstreamJson, looksLikeHtml } from "../../src/utils/upstreamResponse";
+
+const NGINX_502 = "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body><h1>502 Bad Gateway</h1></body></html>";
+
+describe("interpretUpstreamJson", () => {
+  it("returns parsed JSON for a successful response", () => {
+    const result = interpretUpstreamJson<{ login: string }>("GitHub", { status: 200, text: '{"login":"octocat"}' });
+
+    expect(result).toEqual({ ok: true, status: 200, data: { login: "octocat" } });
+  });
+
+  it("treats an empty successful body as null data", () => {
+    expect(interpretUpstreamJson("GitHub", { status: 204, text: "" })).toEqual({ ok: true, status: 204, data: null });
+  });
+
+  it("passes JSON error bodies through untouched", () => {
+    const text = '{"message":"Not Found","documentation_url":"https://docs.github.com"}';
+
+    expect(interpretUpstreamJson("GitHub", { status: 404, text })).toEqual({ ok: false, status: 404, error: text });
+  });
+
+  it("describes an HTML error page instead of leaking a SyntaxError", () => {
+    const result = interpretUpstreamJson("GitHub", {
+      status: 502,
+      statusText: "Bad Gateway",
+      contentType: "text/html",
+      text: NGINX_502,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 502,
+      error: "GitHub returned HTTP 502 Bad Gateway with an HTML page instead of JSON",
+    });
+  });
+
+  it("detects HTML by body when the content type is missing", () => {
+    const result = interpretUpstreamJson("Codeberg", { status: 503, text: NGINX_502 });
+
+    expect(result).toMatchObject({ ok: false, error: "Codeberg returned HTTP 503 with an HTML page instead of JSON" });
+  });
+
+  it("flags a successful status with a non-JSON body", () => {
+    const result = interpretUpstreamJson("GitLab", { status: 200, statusText: "OK", text: "Service temporarily unavailable" });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 200,
+      error: "GitLab returned HTTP 200 OK with a non-JSON response instead of JSON",
+    });
+  });
+});
+
+describe("looksLikeHtml", () => {
+  it("recognises doctype, html tag and content type", () => {
+    expect(looksLikeHtml("<!DOCTYPE html><html>")).toBe(true);
+    expect(looksLikeHtml("  <html lang=\"en\">")).toBe(true);
+    expect(looksLikeHtml("plain text", "text/html; charset=utf-8")).toBe(true);
+    expect(looksLikeHtml('{"a":1}', "application/json")).toBe(false);
+    expect(looksLikeHtml("<svg></svg>")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The UI frequently showed:

```
Unexpected token '<', "<html>
<h"... is not valid JSON
```

That is a `SyntaxError` from `response.json()`. The two GraphQL helpers (`src/server/githubClient.ts` and `src/server/providers/github.ts`) parsed the body without checking the status, so whenever GitHub or a gateway in front of it answered with an HTML 5xx page, the parser exception was caught by the route handler and forwarded to the browser as the error message. The REST helpers checked `response.ok` but still returned the raw HTML as the error text, and the browser client had the same blind `response.json()` for a reverse proxy in front of Gitdeck.

## Fix

- New pure helper `interpretUpstreamJson(service, { status, statusText, contentType, text })` in `src/utils/upstreamResponse.ts`, with unit tests. JSON bodies pass through untouched (error bodies stay verbatim so callers can still inspect them). Anything else becomes `"<service> returned HTTP 502 Bad Gateway with an HTML page instead of JSON"`.
- `src/server/upstream.ts` wraps it for `fetch` responses (`readUpstreamJson`, `requireUpstreamJson`).
- Applied to every provider fetch that parsed JSON: GitHub GraphQL and REST, device-flow token exchange, identity lookups and notifications for GitHub, Forgejo and GitLab.
- `src/api/github.ts` (browser) uses the same helper, so an HTML page from a proxy in front of Gitdeck is reported as "Gitdeck server returned HTTP 502 ..." instead of a parser error.

## Verification

- `npm test`: 22 files, 115 tests passing (7 new).
- `npm run typecheck`: no new errors.
- `npm run build`: ok.